### PR TITLE
[PURPLE-68] 이메일 인증코드 검증 API

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/port/in/ConfirmEmailVerificationCodeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/ConfirmEmailVerificationCodeUseCase.java
@@ -4,7 +4,7 @@ public interface ConfirmEmailVerificationCodeUseCase {
 
     void invoke(
         String email,
-        String verifyCode
+        String verificationCode
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/ConfirmEmailVerificationCodeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/ConfirmEmailVerificationCodeUseCase.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.user.port.in;
+
+public interface ConfirmEmailVerificationCodeUseCase {
+
+    void invoke(
+        String email,
+        String verifyCode
+    );
+
+}

--- a/src/main/java/com/pikachu/purple/application/user/port/out/UserEmailVerificationRepository.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/out/UserEmailVerificationRepository.java
@@ -4,8 +4,13 @@ public interface UserEmailVerificationRepository {
 
     void save(
         String email,
-        String verifiedNumber,
+        String verifyCode,
         Long expirationTime
+    );
+
+    void confirm(
+        String email,
+        String verifyCode
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/out/UserEmailVerificationRepository.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/out/UserEmailVerificationRepository.java
@@ -4,13 +4,13 @@ public interface UserEmailVerificationRepository {
 
     void save(
         String email,
-        String verifyCode,
+        String verificationCode,
         Long expirationTime
     );
 
     void confirm(
         String email,
-        String verifyCode
+        String verificationCode
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/ConfirmEmailVerificationCodeService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/ConfirmEmailVerificationCodeService.java
@@ -14,11 +14,11 @@ public class ConfirmEmailVerificationCodeService implements ConfirmEmailVerifica
     @Override
     public void invoke(
         String email,
-        String verifyCode
+        String verificationCode
     ) {
         userEmailVerificationRepository.confirm(
             email,
-            verifyCode
+            verificationCode
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/user/service/application/ConfirmEmailVerificationCodeService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/ConfirmEmailVerificationCodeService.java
@@ -1,0 +1,25 @@
+package com.pikachu.purple.application.user.service.application;
+
+import com.pikachu.purple.application.user.port.in.ConfirmEmailVerificationCodeUseCase;
+import com.pikachu.purple.application.user.port.out.UserEmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConfirmEmailVerificationCodeService implements ConfirmEmailVerificationCodeUseCase {
+
+    private final UserEmailVerificationRepository userEmailVerificationRepository;
+
+    @Override
+    public void invoke(
+        String email,
+        String verifyCode
+    ) {
+        userEmailVerificationRepository.confirm(
+            email,
+            verifyCode
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,7 +44,7 @@ public interface AuthApi {
     @PostMapping("/verify-code/send")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void send(
-        @RequestBody EmailVerificationRequest request
+        @RequestBody @Valid EmailVerificationRequest request
     );
 
     @Operation(summary = "회원가입시 이메일 인증코드 확인")
@@ -59,6 +60,6 @@ public interface AuthApi {
     )
     @PostMapping("/verify-code/confirm")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    void confirm(@RequestBody EmailVerificationCodeRequest request);
+    void confirm(@RequestBody @Valid EmailVerificationCodeRequest request);
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.bootstrap.auth.api;
 
+import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationCodeRequest;
 import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
@@ -39,11 +40,25 @@ public interface AuthApi {
             )
         }
     )
-
     @PostMapping("/verify-code/send")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void send(
-        @RequestBody final EmailVerificationRequest request
+        @RequestBody EmailVerificationRequest request
     );
+
+    @Operation(summary = "회원가입시 이메일 인증코드 확인")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "204", description = "이메일 인증코드 확인 성공"
+            ),
+            @ApiResponse(
+                responseCode = "400", description = "U003: 인증코드가 유효하지 않습니다."
+            )
+        }
+    )
+    @PostMapping("/verify-code/confirm")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void confirm(@RequestBody EmailVerificationCodeRequest request);
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -10,9 +10,7 @@ import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationCodeReques
 import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -33,13 +31,13 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public void send(@RequestBody @Valid EmailVerificationRequest request){
+    public void send(EmailVerificationRequest request){
         sendEmailVerificationUseCase.invoke(request.getEmail());
     }
 
     @Override
-    public void confirm(@RequestBody @Valid EmailVerificationCodeRequest request){
-        confirmEmailVerificationCodeUseCase.invoke(request.getEmail(), request.getVerifyCode());
+    public void confirm(EmailVerificationCodeRequest request){
+        confirmEmailVerificationCodeUseCase.invoke(request.getEmail(), request.getVerificationCode());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package com.pikachu.purple.bootstrap.auth.controller;
 
+import com.pikachu.purple.application.user.port.in.ConfirmEmailVerificationCodeUseCase;
 import com.pikachu.purple.application.user.port.in.SendEmailVerificationUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase.Command;
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase.Result;
 import com.pikachu.purple.bootstrap.auth.api.AuthApi;
+import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationCodeRequest;
 import com.pikachu.purple.bootstrap.auth.dto.request.EmailVerificationRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
@@ -19,6 +21,7 @@ public class AuthController implements AuthApi {
 
     private final SocialLoginTryUseCase socialLoginTryUseCase;
     private final SendEmailVerificationUseCase sendEmailVerificationUseCase;
+    private final ConfirmEmailVerificationCodeUseCase confirmEmailVerificationCodeUseCase;
 
     @Override
     public SocialLoginTryResponse loginTry(SocialLoginProvider socialLoginProvider) {
@@ -32,6 +35,11 @@ public class AuthController implements AuthApi {
     @Override
     public void send(@RequestBody @Valid EmailVerificationRequest request){
         sendEmailVerificationUseCase.invoke(request.getEmail());
+    }
+
+    @Override
+    public void confirm(@RequestBody @Valid EmailVerificationCodeRequest request){
+        confirmEmailVerificationCodeUseCase.invoke(request.getEmail(), request.getVerifyCode());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/EmailVerificationCodeRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/EmailVerificationCodeRequest.java
@@ -1,0 +1,19 @@
+package com.pikachu.purple.bootstrap.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
+public class EmailVerificationCodeRequest {
+
+    @NotBlank
+    private final String email;
+
+    @NotBlank
+    private final String verifyCode;
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/EmailVerificationCodeRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/EmailVerificationCodeRequest.java
@@ -14,6 +14,6 @@ public class EmailVerificationCodeRequest {
     private final String email;
 
     @NotBlank
-    private final String verifyCode;
+    private final String verificationCode;
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
@@ -20,4 +20,8 @@ public class BusinessException extends RuntimeException {
         ErrorCode.INVALID_EMAIL_FORMAT
     );
 
+    public static final BusinessException InvalidVerifyCodeException = new BusinessException(
+        ErrorCode.INVALID_VERIFY_CODE
+    );
+
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -14,16 +14,21 @@ public enum ErrorCode {
         "서버에 오류가 발생하였습니다."
     ),
 
-    // User
+    // Auth
     EMAIL_ALREADY_EXISTED(
         409,
-        "U001",
+        "A001",
         "이미 회원가입을 완료한 이메일입니다."
     ),
     INVALID_EMAIL_FORMAT(
         400,
-        "U002",
+        "A002",
         "이메일 형식이 유효하지 않습니다."
+    ),
+    INVALID_VERIFY_CODE(
+        400,
+        "A003",
+        "인증코드가 유효하지 않습니다."
     );
 
     private final int status;

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/common/RedisConfig.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/common/RedisConfig.java
@@ -5,11 +5,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 public class RedisConfig {
     @Value(value = "${spring.data.redis.host}")
     private String host;

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserEmailVerificationRedisAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserEmailVerificationRedisAdaptor.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.infrastructure.redis.user.adapter;
 
+import static com.pikachu.purple.bootstrap.common.exception.BusinessException.InvalidVerifyCodeException;
+
 import com.pikachu.purple.application.user.port.out.UserEmailVerificationRepository;
 import com.pikachu.purple.infrastructure.redis.user.entity.UserEmailVerificationRedisHash;
 import com.pikachu.purple.infrastructure.redis.user.repository.UserEmailVerificationRedisRepository;
@@ -15,16 +17,26 @@ public class UserEmailVerificationRedisAdaptor implements UserEmailVerificationR
     @Override
     public void save(
         String email,
-        String verifiedNumber,
+        String verifyCode,
         Long expirationTime
     ){
         UserEmailVerificationRedisHash hash = UserEmailVerificationRedisHash.builder()
-            .verifiedEmail(email)
-            .verifiedNumber(verifiedNumber)
+            .verifyEmail(email)
+            .verifyCode(verifyCode)
             .expirationTime(expirationTime)
             .build();
 
         userEmailVerificationRedisHash.save(hash);
+    }
+
+    @Override
+    public void confirm(
+        String email,
+        String verifyCode
+    ){
+        userEmailVerificationRedisHash.findByVerifyCode(verifyCode)
+            .filter(userEmailVerification -> email.equals(userEmailVerification.getVerifyEmail()))
+            .orElseThrow(() -> InvalidVerifyCodeException);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserEmailVerificationRedisAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserEmailVerificationRedisAdaptor.java
@@ -17,12 +17,12 @@ public class UserEmailVerificationRedisAdaptor implements UserEmailVerificationR
     @Override
     public void save(
         String email,
-        String verifyCode,
+        String verificationCode,
         Long expirationTime
-    ){
+    ) {
         UserEmailVerificationRedisHash hash = UserEmailVerificationRedisHash.builder()
-            .verifyEmail(email)
-            .verifyCode(verifyCode)
+            .email(email)
+            .verificationCode(verificationCode)
             .expirationTime(expirationTime)
             .build();
 
@@ -32,10 +32,10 @@ public class UserEmailVerificationRedisAdaptor implements UserEmailVerificationR
     @Override
     public void confirm(
         String email,
-        String verifyCode
-    ){
-        userEmailVerificationRedisHash.findByVerifyCode(verifyCode)
-            .filter(userEmailVerification -> email.equals(userEmailVerification.getVerifyEmail()))
+        String verificationCode
+    ) {
+        userEmailVerificationRedisHash.findById(email)
+            .filter(userEmailVerificationInfo -> verificationCode.equals(userEmailVerificationInfo.getVerificationCode()))
             .orElseThrow(() -> InvalidVerifyCodeException);
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserEmailVerificationRedisHash.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserEmailVerificationRedisHash.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,21 +18,22 @@ public class UserEmailVerificationRedisHash implements Serializable {
     @Id
     private Long id;
 
-    private String verifiedEmail;
+    private String verifyEmail;
 
-    private String verifiedNumber;
+    @Indexed
+    private String verifyCode;
 
     @TimeToLive
     private Long expirationTime;
 
     @Builder
     public UserEmailVerificationRedisHash(
-        String verifiedEmail,
-        String verifiedNumber,
+        String verifyEmail,
+        String verifyCode,
         Long expirationTime
     ){
-        this.verifiedEmail = verifiedEmail;
-        this.verifiedNumber = verifiedNumber;
+        this.verifyEmail = verifyEmail;
+        this.verifyCode = verifyCode;
         this.expirationTime = expirationTime;
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserEmailVerificationRedisHash.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserEmailVerificationRedisHash.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
-import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,24 +15,21 @@ import org.springframework.data.redis.core.index.Indexed;
 public class UserEmailVerificationRedisHash implements Serializable {
 
     @Id
-    private Long id;
+    private String email;
 
-    private String verifyEmail;
-
-    @Indexed
-    private String verifyCode;
+    private String verificationCode;
 
     @TimeToLive
     private Long expirationTime;
 
     @Builder
     public UserEmailVerificationRedisHash(
-        String verifyEmail,
-        String verifyCode,
+        String email,
+        String verificationCode,
         Long expirationTime
     ){
-        this.verifyEmail = verifyEmail;
-        this.verifyCode = verifyCode;
+        this.email = email;
+        this.verificationCode = verificationCode;
         this.expirationTime = expirationTime;
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserEmailVerificationRedisRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserEmailVerificationRedisRepository.java
@@ -1,13 +1,10 @@
 package com.pikachu.purple.infrastructure.redis.user.repository;
 
 import com.pikachu.purple.infrastructure.redis.user.entity.UserEmailVerificationRedisHash;
-import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserEmailVerificationRedisRepository extends CrudRepository<UserEmailVerificationRedisHash, Long> {
-
-    Optional<UserEmailVerificationRedisHash> findByVerifyCode(String verifyCode);
+public interface UserEmailVerificationRedisRepository extends CrudRepository<UserEmailVerificationRedisHash, String> {
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserEmailVerificationRedisRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserEmailVerificationRedisRepository.java
@@ -1,10 +1,13 @@
 package com.pikachu.purple.infrastructure.redis.user.repository;
 
 import com.pikachu.purple.infrastructure.redis.user.entity.UserEmailVerificationRedisHash;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserEmailVerificationRedisRepository extends CrudRepository<UserEmailVerificationRedisHash, Long> {
+
+    Optional<UserEmailVerificationRedisHash> findByVerifyCode(String verifyCode);
 
 }


### PR DESCRIPTION
# Summary
- 이메일 인증코드에 필요한 값은 email, verifyCode입니다.

# 논의사항
- 현재 이메일 인증코드 검증을 할 때 email, verifyCode로 redis에서 값을 찾고 있는데, 두 attribute가 key가 아니라서 verifyCode에 @indexed를 붙여 보조 인덱스로 값을 찾아 검증을 하고 있습니다.
- 이 로직이 좋지 않다고 판단이 들어 이메일 코드전송 api에서 return 값으로 key값인 id를 반환하여 id, verifyCode로 값을 찾는건 어떤지 궁금합니다.