### PR TITLE
[PURPLE-87] 인증 정보 전역 provider 작성

### DIFF
--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -49,6 +49,12 @@ public enum ErrorCode {
         "인증코드가 유효하지 않습니다."
     ),
 
+    USER_NOT_AUTHENTICATED(
+        404,
+        "U006",
+        "인증되지 않은 사용자입니다."
+    ),
+
     // Jwt
     JWT_EXPIRED_EXCEPTION(
         400,

--- a/src/main/java/com/pikachu/purple/support/security/SecurityProvider.java
+++ b/src/main/java/com/pikachu/purple/support/security/SecurityProvider.java
@@ -1,0 +1,24 @@
+package com.pikachu.purple.support.security;
+
+import com.pikachu.purple.bootstrap.common.exception.BusinessException;
+import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
+import com.pikachu.purple.bootstrap.common.vo.UserAuthentication;
+import com.pikachu.purple.support.security.auth.Authentication;
+import com.pikachu.purple.support.security.auth.SecurityContext;
+import com.pikachu.purple.support.security.auth.SecurityContextHolder;
+
+public class SecurityProvider {
+
+    public static UserAuthentication getCurrentUserAuthentication() {
+        SecurityContext<Authentication> authenticationContext = SecurityContextHolder.getContext();
+
+        UserAuthentication userAuthentication = (UserAuthentication) authenticationContext.getAuthentication();
+
+        if (userAuthentication == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_AUTHENTICATED);
+        }
+
+        return userAuthentication;
+    }
+
+}


### PR DESCRIPTION
### Summary
* 인증 정보를 전역적으로 가져올 수 있는 provider를 작성했습니다.
* `getCurrentUserAuthentication()`을 통해 Authentication 객체를 가져와 사용할 수 있어요!
* 현재 커스텀하게 정의한 구현체인 UserAuthentication에는 email, userId를 포함하고 있습니다!