### PR TITLE
[PURPLE-84] Refresh Token 갱신 API

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/port/in/RefreshJwtTokenUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/RefreshJwtTokenUseCase.java
@@ -1,0 +1,19 @@
+package com.pikachu.purple.application.user.port.in;
+
+public interface RefreshJwtTokenUseCase {
+
+    RefreshJwtTokenUseCase.Result invoke(RefreshJwtTokenUseCase.Command command);
+
+    record Command(
+        String jwtToken
+    ) {
+
+    }
+
+    record Result(
+        String jwtToken
+    ) {
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/user/port/out/UserTokenRepository.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/out/UserTokenRepository.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.application.user.port.out;
 
+import java.util.Optional;
+
 public interface UserTokenRepository {
 
     void saveRefreshToken(
@@ -8,10 +10,18 @@ public interface UserTokenRepository {
         Long expirationSeconds
     );
 
-    void saveJwtToken(
+    void saveAccessToken(
         Long userId,
-        String jwtToken,
+        String accessToken,
         Long expirationSeconds
+    );
+
+    Optional<String> findAccessTokenByUserId(
+        Long userId
+    );
+
+    Optional<String> findRefreshTokenByUserId(
+        Long userId
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
@@ -40,4 +40,5 @@ public class RefreshJwtTokenApplicationService implements RefreshJwtTokenUseCase
             )
         );
     }
+
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
@@ -1,0 +1,43 @@
+package com.pikachu.purple.application.user.service.application;
+
+import com.pikachu.purple.application.user.port.in.RefreshJwtTokenUseCase;
+import com.pikachu.purple.application.user.port.out.UserTokenRepository;
+import com.pikachu.purple.application.user.service.domain.UserDomainService;
+import com.pikachu.purple.application.user.service.util.UserTokenService;
+import com.pikachu.purple.bootstrap.common.exception.BusinessException;
+import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
+import com.pikachu.purple.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshJwtTokenApplicationService implements RefreshJwtTokenUseCase {
+
+    private final UserDomainService userDomainService;
+    private final UserTokenService userTokenService;
+    private final UserTokenRepository userTokenRepository;
+
+    @Override
+    public Result invoke(Command command) {
+        String jwtToken = command.jwtToken();
+        String refreshToken = userTokenService.resolveJwtToken(jwtToken).getRefreshToken();
+
+        Long userId = userTokenService.resolveRefreshToken(refreshToken).getUserId();
+
+        userTokenRepository.findRefreshTokenByUserId(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        User user = userDomainService.getById(userId);
+        String accessToken = userTokenService.generateAccessToken(user);
+        String newRefreshToken = userTokenService.generateRefreshToken(user);
+
+        return new RefreshJwtTokenUseCase.Result(
+            userTokenService.generateJwtToken(
+                user,
+                accessToken,
+                newRefreshToken
+            )
+        );
+    }
+}

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/UserDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/UserDomainService.java
@@ -13,6 +13,8 @@ public interface UserDomainService {
         String nickname
     );
 
+    User getById(Long userId);
+
     User findByEmailAndSocialLoginProvider(
         String email,
         SocialLoginProvider socialLoginProvider

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserDomainServiceImpl.java
@@ -27,6 +27,11 @@ public class UserDomainServiceImpl implements UserDomainService {
     }
 
     @Override
+    public User getById(Long userId) {
+        return userRepository.getById(userId);
+    }
+
+    @Override
     public void updateNickname(
         Long userId,
         String nickname

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
@@ -1,5 +1,8 @@
 package com.pikachu.purple.application.user.service.util.impl;
 
+import static com.pikachu.purple.bootstrap.common.exception.BusinessException.AccessTokenExpiredException;
+import static com.pikachu.purple.bootstrap.common.exception.BusinessException.RefreshTokenNotFoundException;
+
 import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.common.properties.JwtTokenProperties;
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
@@ -46,9 +49,18 @@ public class UserTokenServiceImpl implements UserTokenService {
 
     @Override
     public AccessToken resolveAccessToken(String accessToken) {
-        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(accessToken, jwtTokenProperties.getAccess().secret());
-        Long userId = Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString().replace("\"", ""));
+        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(
+            accessToken,
+            jwtTokenProperties.getAccess().secret()
+        );
+        Long userId = Long.valueOf(
+            jwtClaims.getCustomClaims().get("userId").toString().replace("\"", "")
+        );
         String email = jwtClaims.getCustomClaims().get("email").toString().replace("\"", "");
+
+        userTokenRepository.findAccessTokenByUserId(
+            Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
+        ).orElseThrow(() -> AccessTokenExpiredException);
 
         return new AccessToken(
             userId,
@@ -58,7 +70,14 @@ public class UserTokenServiceImpl implements UserTokenService {
 
     @Override
     public RefreshToken resolveRefreshToken(String refreshToken) {
-        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(refreshToken, jwtTokenProperties.getRefresh().secret());
+        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(
+            refreshToken,
+            jwtTokenProperties.getRefresh().secret()
+        );
+
+        userTokenRepository.findRefreshTokenByUserId(
+            Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
+        ).orElseThrow(() -> RefreshTokenNotFoundException);
 
         return new RefreshToken(
             Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
@@ -67,7 +86,10 @@ public class UserTokenServiceImpl implements UserTokenService {
 
     @Override
     public JwtToken resolveJwtToken(String jwtToken) {
-        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(jwtToken, jwtTokenProperties.getJwt().secret());
+        JwtClaims jwtClaims = jwtTokenProvider.verifyToken(
+            jwtToken,
+            jwtTokenProperties.getJwt().secret()
+        );
 
         return new JwtToken(
             jwtClaims.getCustomClaims().get("accessToken").toString(),
@@ -85,7 +107,9 @@ public class UserTokenServiceImpl implements UserTokenService {
         JwtClaims jwtClaims = new JwtClaims(
             new RegisteredClaims(
                 null,
-                Date.from(Instant.now().plusSeconds(jwtTokenProperties.getAccess().expireSeconds())),
+                Date.from(
+                    Instant.now().plusSeconds(jwtTokenProperties.getAccess().expireSeconds())
+                ),
                 Date.from(Instant.now()),
                 Date.from(Instant.now()),
                 jwtTokenProperties.getIssuer(),
@@ -93,6 +117,17 @@ public class UserTokenServiceImpl implements UserTokenService {
                 null
             ),
             customClaims
+        );
+
+        String accessToken = jwtTokenProvider.createToken(
+            jwtClaims,
+            jwtTokenProperties.getAccess().secret()
+        );
+
+        userTokenRepository.saveAccessToken(
+            user.getId(),
+            accessToken,
+            jwtTokenProperties.getAccess().expireSeconds()
         );
 
         return jwtTokenProvider.createToken(jwtClaims, jwtTokenProperties.getAccess().secret());
@@ -108,7 +143,8 @@ public class UserTokenServiceImpl implements UserTokenService {
             new RegisteredClaims(
                 null,
                 Date.from(
-                    Instant.now().plusSeconds(jwtTokenProperties.getRefresh().expireSeconds())),
+                    Instant.now().plusSeconds(jwtTokenProperties.getRefresh().expireSeconds())
+                ),
                 Date.from(Instant.now()),
                 Date.from(Instant.now()),
                 jwtTokenProperties.getIssuer(),
@@ -122,7 +158,6 @@ public class UserTokenServiceImpl implements UserTokenService {
             jwtClaims,
             jwtTokenProperties.getRefresh().secret()
         );
-
 
         userTokenRepository.saveRefreshToken(
             user.getId(),
@@ -159,19 +194,10 @@ public class UserTokenServiceImpl implements UserTokenService {
             customClaims
         );
 
-        String jwtToken = jwtTokenProvider.createToken(
+        return jwtTokenProvider.createToken(
             jwtClaims,
             jwtTokenProperties.getJwt().secret()
         );
-
-
-        userTokenRepository.saveJwtToken(
-            user.getId(),
-            jwtToken,
-            jwtTokenProperties.getJwt().expireSeconds()
-        );
-
-        return jwtToken;
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.pikachu.purple.application.user.service.util.impl;
 
 import static com.pikachu.purple.bootstrap.common.exception.BusinessException.AccessTokenExpiredException;
-import static com.pikachu.purple.bootstrap.common.exception.BusinessException.RefreshTokenNotFoundException;
 
 import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.common.properties.JwtTokenProperties;
@@ -14,6 +13,8 @@ import com.pikachu.purple.application.user.vo.tokens.AccessToken;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.application.user.vo.tokens.JwtToken;
 import com.pikachu.purple.application.user.vo.tokens.RefreshToken;
+import com.pikachu.purple.bootstrap.common.exception.BusinessException;
+import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
 import com.pikachu.purple.domain.user.entity.User;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import com.pikachu.purple.support.security.auth.util.JwtTokenProvider;
@@ -77,7 +78,7 @@ public class UserTokenServiceImpl implements UserTokenService {
 
         userTokenRepository.findRefreshTokenByUserId(
             Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
-        ).orElseThrow(() -> RefreshTokenNotFoundException);
+        ).orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         return new RefreshToken(
             Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())

--- a/src/main/java/com/pikachu/purple/application/user/vo/tokens/RefreshToken.java
+++ b/src/main/java/com/pikachu/purple/application/user/vo/tokens/RefreshToken.java
@@ -1,7 +1,11 @@
 package com.pikachu.purple.application.user.vo.tokens;
 
+import lombok.Getter;
+
+@Getter
 public class RefreshToken {
-    private Long userId;
+
+    private final Long userId;
 
     public RefreshToken(Long userId) {
         this.userId = userId;

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -1,6 +1,8 @@
 package com.pikachu.purple.bootstrap.auth.api;
 
 import com.auth0.jwk.JwkException;
+import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
+import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +13,7 @@ import java.net.URISyntaxException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -34,5 +37,12 @@ public interface AuthApi {
         @RequestParam String code,
         HttpServletResponse response
     ) throws IOException, JwkException, URISyntaxException;
+
+    @Operation(summary = "Jwt Token Refresh API")
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    RefreshJwtTokenResponse refreshJwtToken(
+        @RequestBody RefreshJwtTokenRequest request
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -1,9 +1,12 @@
 package com.pikachu.purple.bootstrap.auth.controller;
 
 import com.auth0.jwk.JwkException;
+import com.pikachu.purple.application.user.port.in.RefreshJwtTokenUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginUseCase;
 import com.pikachu.purple.bootstrap.auth.api.AuthApi;
+import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
+import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,6 +21,7 @@ public class AuthController implements AuthApi {
 
     private final SocialLoginTryUseCase socialLoginTryUseCase;
     private final SocialLoginUseCase socialLoginUseCase;
+    private final RefreshJwtTokenUseCase refreshJwtTokenUseCase;
 
     @Override
     public SocialLoginTryResponse socialLoginTry(SocialLoginProvider socialLoginProvider) {
@@ -44,4 +48,14 @@ public class AuthController implements AuthApi {
         response.sendRedirect(result.socialLoginSuccessUrl().toString());
     }
 
+    @Override
+    public RefreshJwtTokenResponse refreshJwtToken(RefreshJwtTokenRequest request) {
+        RefreshJwtTokenUseCase.Result result = refreshJwtTokenUseCase.invoke(
+            new RefreshJwtTokenUseCase.Command(
+                request.jwtToken()
+            )
+        );
+
+        return new RefreshJwtTokenResponse(result.jwtToken());
+    }
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/RefreshJwtTokenRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/RefreshJwtTokenRequest.java
@@ -1,0 +1,6 @@
+package com.pikachu.purple.bootstrap.auth.dto.request;
+
+public record RefreshJwtTokenRequest(
+    String jwtToken
+) {
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/response/RefreshJwtTokenResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/response/RefreshJwtTokenResponse.java
@@ -1,0 +1,6 @@
+package com.pikachu.purple.bootstrap.auth.dto.response;
+
+public record RefreshJwtTokenResponse(
+    String jwtToken
+) {
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
@@ -32,4 +32,16 @@ public class BusinessException extends RuntimeException {
         ErrorCode.INVALID_VERIFY_CODE
     );
 
+    public static final BusinessException AccessTokenExpiredException = new BusinessException(
+        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
+    );
+
+    public static final BusinessException RefreshTokenExpiredException = new BusinessException(
+        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
+    );
+
+    public static final BusinessException RefreshTokenNotFoundException = new BusinessException(
+        ErrorCode.REFRESH_TOKEN_NOT_FOUND
+    );
+
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -49,6 +49,12 @@ public enum ErrorCode {
         "인증코드가 유효하지 않습니다."
     ),
 
+    USER_NOT_AUTHENTICATED(
+        404,
+        "U006",
+        "인증되지 않은 사용자입니다."
+    ),
+
     // Jwt
     JWT_EXPIRED_EXCEPTION(
         400,

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -56,15 +56,30 @@ public enum ErrorCode {
     ),
 
     // Jwt
-    JWT_EXPIRED_EXCEPTION(
+    ACCESS_TOKEN_EXPIRED_EXCEPTION(
         400,
         "J001",
-        "토큰이 만료되었습니다."
+        "액세스 토큰이 만료되었습니다."
+    ),
+    REFRESH_TOKEN_EXPIRED_EXCEPTION(
+        400,
+        "J002",
+        "리프레시 토큰이 만료되었습니다."
     ),
     JWT_VERIFICATION_EXCEPTION(
         400,
-        "J002",
+        "J003",
         "토큰 유효성 검사에 실패했습니다."
+    ),
+    JWT_EXPIRED_EXCEPTION(
+        400,
+        "J004",
+        "토큰이 만료되었습니다."
+    ),
+    REFRESH_TOKEN_NOT_FOUND(
+        404,
+        "J005",
+        "리프레시 토큰을 찾을 수 없습니다."
     );
 
     private final int status;

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserTokenRedisAdapter.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserTokenRedisAdapter.java
@@ -1,10 +1,11 @@
 package com.pikachu.purple.infrastructure.redis.user.adapter;
 
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
-import com.pikachu.purple.infrastructure.redis.user.entity.UserJwtTokenRedisHash;
+import com.pikachu.purple.infrastructure.redis.user.entity.UserAccessTokenRedisHash;
 import com.pikachu.purple.infrastructure.redis.user.entity.UserRefreshTokenRedisHash;
-import com.pikachu.purple.infrastructure.redis.user.repository.UserJwtTokenRedisRepository;
+import com.pikachu.purple.infrastructure.redis.user.repository.UserAccessTokenRedisRepository;
 import com.pikachu.purple.infrastructure.redis.user.repository.UserRefreshTokenRedisRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class UserTokenRedisAdapter implements UserTokenRepository {
 
     private final UserRefreshTokenRedisRepository userRefreshTokenRedisRepository;
-    private final UserJwtTokenRedisRepository userJwtTokenRedisRepository;
+    private final UserAccessTokenRedisRepository userAccessTokenRedisRepository;
 
     @Override
     public void saveRefreshToken(
@@ -31,18 +32,37 @@ public class UserTokenRedisAdapter implements UserTokenRepository {
     }
 
     @Override
-    public void saveJwtToken(
+    public void saveAccessToken(
         Long userId,
-        String jwtToken,
+        String accessToken,
         Long expirationSeconds
     ) {
-        UserJwtTokenRedisHash userJwtTokenRedisHash = new UserJwtTokenRedisHash(
+        UserAccessTokenRedisHash userAccessTokenRedisHash = new UserAccessTokenRedisHash(
             userId,
-            jwtToken,
+            accessToken,
             expirationSeconds
         );
 
-        userJwtTokenRedisRepository.save(userJwtTokenRedisHash);
+        userAccessTokenRedisRepository.save(userAccessTokenRedisHash);
     }
 
+    @Override
+    public Optional<String> findAccessTokenByUserId(Long userId) {
+        Optional<UserAccessTokenRedisHash> userAccessTokenRedisHash = userAccessTokenRedisRepository.findById(
+            userId);
+
+        String accessToken = userAccessTokenRedisHash.get().getAccessToken();
+
+        return Optional.of(accessToken);
+    }
+
+    @Override
+    public Optional<String> findRefreshTokenByUserId(Long userId) {
+        Optional<UserRefreshTokenRedisHash> userRefreshTokenRedisHash = userRefreshTokenRedisRepository.findById(
+            userId);
+
+        String refreshToken = userRefreshTokenRedisHash.get().getRefreshToken();
+
+        return Optional.of(refreshToken);
+    }
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserAccessTokenRedisHash.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserAccessTokenRedisHash.java
@@ -1,0 +1,29 @@
+package com.pikachu.purple.infrastructure.redis.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "user_access_token")
+public class UserAccessTokenRedisHash {
+
+    @Id
+    private Long id;
+
+    private String accessToken;
+
+    @TimeToLive
+    private Long expirationSeconds;
+
+    public UserAccessTokenRedisHash(Long id, String accessToken, Long expirationSeconds) {
+        this.id = id;
+        this.accessToken = accessToken;
+        this.expirationSeconds = expirationSeconds;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserAccessTokenRedisHash.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/entity/UserAccessTokenRedisHash.java
@@ -20,7 +20,11 @@ public class UserAccessTokenRedisHash {
     @TimeToLive
     private Long expirationSeconds;
 
-    public UserAccessTokenRedisHash(Long id, String accessToken, Long expirationSeconds) {
+    public UserAccessTokenRedisHash(
+        Long id,
+        String accessToken,
+        Long expirationSeconds
+    ) {
         this.id = id;
         this.accessToken = accessToken;
         this.expirationSeconds = expirationSeconds;

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserAccessTokenRedisRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/repository/UserAccessTokenRedisRepository.java
@@ -1,0 +1,11 @@
+package com.pikachu.purple.infrastructure.redis.user.repository;
+
+import com.pikachu.purple.infrastructure.redis.user.entity.UserAccessTokenRedisHash;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserAccessTokenRedisRepository extends
+    CrudRepository<UserAccessTokenRedisHash, Long> {
+
+}

--- a/src/main/java/com/pikachu/purple/support/security/SecurityProvider.java
+++ b/src/main/java/com/pikachu/purple/support/security/SecurityProvider.java
@@ -1,0 +1,24 @@
+package com.pikachu.purple.support.security;
+
+import com.pikachu.purple.bootstrap.common.exception.BusinessException;
+import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
+import com.pikachu.purple.bootstrap.common.vo.UserAuthentication;
+import com.pikachu.purple.support.security.auth.Authentication;
+import com.pikachu.purple.support.security.auth.SecurityContext;
+import com.pikachu.purple.support.security.auth.SecurityContextHolder;
+
+public class SecurityProvider {
+
+    public static UserAuthentication getCurrentUserAuthentication() {
+        SecurityContext<Authentication> authenticationContext = SecurityContextHolder.getContext();
+
+        UserAuthentication userAuthentication = (UserAuthentication) authenticationContext.getAuthentication();
+
+        if (userAuthentication == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_AUTHENTICATED);
+        }
+
+        return userAuthentication;
+    }
+
+}


### PR DESCRIPTION
### Summary
* 토큰 리프레시 로직 구현하였습니다.
* AccessToken 만료 시, 액세스 토큰 만료 에러가 발생합니다.
* 해당 JwtToken을 이용하여 Refresh Token 갱신 API에 태우면 새로운 access, refresh, jwt token을 제공합니다.
* 만약 해당 RefreshToken도 만료된 경우, 리프레시 토큰 만료 에러가 발생합니다.
* 만료 정책 적용을 위해 JwtToken 저장은 불 필요하다고 판단했습니다. 대신, Access Token을 저장하여 Redis에서 관리하도록 변경하였습니다.