### PR TITLE
[PURPLE-83] 유저 선호도 기반 추천 향수 목록 조회 API

### DIFF
--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeGetByUserPreferenceNoteUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeGetByUserPreferenceNoteUseCase.java
@@ -1,13 +1,17 @@
 package com.pikachu.purple.application.perfume.port.in;
 
 import com.pikachu.purple.domain.perfume.Perfume;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
 import java.util.List;
 
 public interface PerfumeGetByUserPreferenceNoteUseCase {
 
     Result invoke();
 
-    record Result(List<Perfume> perfumeList){
+    record Result(
+        List<UserPreferenceNote> userPreferenceNoteList,
+        List<Perfume> perfumeList
+    ) {
 
     }
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeGetByUserPreferenceNoteUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeGetByUserPreferenceNoteUseCase.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.perfume.port.in;
+
+import com.pikachu.purple.domain.perfume.Perfume;
+import java.util.List;
+
+public interface PerfumeGetByUserPreferenceNoteUseCase {
+
+    Result invoke();
+
+    record Result(List<Perfume> perfumeList){
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByPerfumeIdListUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByPerfumeIdListUseCase.java
@@ -7,7 +7,7 @@ public interface PerfumeNoteGetByPerfumeIdListUseCase {
 
     Result invoke(List<Long> perfumeIdList);
 
-    record Result(List<PerfumeNote> perfumeNoteList){
+    record Result(List<PerfumeNote> perfumeNoteList) {
 
     }
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByPerfumeIdListUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByPerfumeIdListUseCase.java
@@ -1,10 +1,9 @@
 package com.pikachu.purple.application.perfume.port.in;
 
 import com.pikachu.purple.domain.perfume.PerfumeNote;
-import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
-public interface PerfumeNoteGetByRatingsUseCase {
+public interface PerfumeNoteGetByPerfumeIdListUseCase {
 
     Result invoke(List<Long> perfumeIdList);
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByRatingsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/PerfumeNoteGetByRatingsUseCase.java
@@ -1,0 +1,15 @@
+package com.pikachu.purple.application.perfume.port.in;
+
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.domain.rating.Rating;
+import java.util.List;
+
+public interface PerfumeNoteGetByRatingsUseCase {
+
+    Result invoke(List<Long> perfumeIdList);
+
+    record Result(List<PerfumeNote> perfumeNoteList){
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeNoteRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeNoteRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.perfume.port.out;
+
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import java.util.List;
+
+public interface PerfumeNoteRepository {
+
+    List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeList);
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeNoteRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeNoteRepository.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface PerfumeNoteRepository {
 
-    List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeList);
+    List<PerfumeNote> getAllByPerfumeIds(List<Long> perfumeList);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 public interface PerfumeRepository {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
-    List<Perfume> findUserPreferenceNotesByUserId(Long userId);
+    List<Perfume> findByUserPreferenceNotes(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface PerfumeRepository {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
+    List<Perfume> findByUserPreferenceNotes(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 public interface PerfumeRepository {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
-    List<Perfume> findByUserPreferenceNotes(Long userId);
+    List<Perfume> findUserPreferenceNotesByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 public interface PerfumeRepository {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
+
     List<Perfume> findByUserPreferenceNotes(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
@@ -19,7 +19,7 @@ public class PerfumeGetByUserPreferenceNoteApplicationService implements Perfume
 
     @Override
     public Result invoke() {
-        List<Perfume> perfumeList = perfumeDomainService.findUserPreferenceNotesByUserId(
+        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(
             getCurrentUserAuthentication().userId());
         UserPreferenceNoteGetUseCase.Result result = userPreferenceNoteGetUseCase.invoke();
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.perfume.service.application;
+
+import com.pikachu.purple.application.perfume.port.in.PerfumeGetByUserPreferenceNoteUseCase;
+import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
+import com.pikachu.purple.domain.perfume.Perfume;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PerfumeGetByUserPreferenceNoteApplicationService implements PerfumeGetByUserPreferenceNoteUseCase {
+
+    private final PerfumeDomainService perfumeDomainService;
+
+    @Override
+    public Result invoke() {
+        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(1L);
+
+        return new Result(perfumeList);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
@@ -19,12 +19,12 @@ public class PerfumeGetByUserPreferenceNoteApplicationService implements Perfume
 
     @Override
     public Result invoke() {
-        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(
-            getCurrentUserAuthentication().userId());
-        UserPreferenceNoteGetUseCase.Result result = userPreferenceNoteGetUseCase.invoke();
+        Long userId = getCurrentUserAuthentication().userId();
+        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(userId);
+        UserPreferenceNoteGetUseCase.Result userPreferenceNoteList = userPreferenceNoteGetUseCase.invoke();
 
         return new Result(
-            result.userPreferenceNoteList(),
+            userPreferenceNoteList.userPreferenceNoteList(),
             perfumeList
         );
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
@@ -19,7 +19,7 @@ public class PerfumeGetByUserPreferenceNoteApplicationService implements Perfume
 
     @Override
     public Result invoke() {
-        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(
+        List<Perfume> perfumeList = perfumeDomainService.findUserPreferenceNotesByUserId(
             getCurrentUserAuthentication().userId());
         UserPreferenceNoteGetUseCase.Result result = userPreferenceNoteGetUseCase.invoke();
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeGetByUserPreferenceNoteApplicationService.java
@@ -1,7 +1,10 @@
 package com.pikachu.purple.application.perfume.service.application;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByUserPreferenceNoteUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
+import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteGetUseCase;
 import com.pikachu.purple.domain.perfume.Perfume;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +15,18 @@ import org.springframework.stereotype.Service;
 public class PerfumeGetByUserPreferenceNoteApplicationService implements PerfumeGetByUserPreferenceNoteUseCase {
 
     private final PerfumeDomainService perfumeDomainService;
+    private final UserPreferenceNoteGetUseCase userPreferenceNoteGetUseCase;
 
     @Override
     public Result invoke() {
-        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(1L);
+        List<Perfume> perfumeList = perfumeDomainService.findByUserPreferenceNotes(
+            getCurrentUserAuthentication().userId());
+        UserPreferenceNoteGetUseCase.Result result = userPreferenceNoteGetUseCase.invoke();
 
-        return new Result(perfumeList);
+        return new Result(
+            result.userPreferenceNoteList(),
+            perfumeList
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.perfume.service.application;
+
+import com.pikachu.purple.application.perfume.port.in.PerfumeNoteGetByRatingsUseCase;
+import com.pikachu.purple.application.perfume.service.domain.PerfumeNoteDomainService;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PerfumeNoteGetByPerfumeIdListApplicationService implements PerfumeNoteGetByRatingsUseCase {
+
+    private final PerfumeNoteDomainService perfumeNoteDomainService;
+
+    @Override
+    public Result invoke(List<Long> perfumeIdList) {
+        List<PerfumeNote> perfumeNoteList = perfumeNoteDomainService.getByPerfumeIdList(perfumeIdList);
+
+        return new Result(perfumeNoteList);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.perfume.service.application;
 
-import com.pikachu.purple.application.perfume.port.in.PerfumeNoteGetByRatingsUseCase;
+import com.pikachu.purple.application.perfume.port.in.PerfumeNoteGetByPerfumeIdListUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeNoteDomainService;
 import com.pikachu.purple.domain.perfume.PerfumeNote;
 import java.util.List;
@@ -9,7 +9,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PerfumeNoteGetByPerfumeIdListApplicationService implements PerfumeNoteGetByRatingsUseCase {
+public class PerfumeNoteGetByPerfumeIdListApplicationService implements
+    PerfumeNoteGetByPerfumeIdListUseCase {
 
     private final PerfumeNoteDomainService perfumeNoteDomainService;
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeNoteGetByPerfumeIdListApplicationService.java
@@ -16,7 +16,7 @@ public class PerfumeNoteGetByPerfumeIdListApplicationService implements
 
     @Override
     public Result invoke(List<Long> perfumeIdList) {
-        List<PerfumeNote> perfumeNoteList = perfumeNoteDomainService.getByPerfumeIdList(perfumeIdList);
+        List<PerfumeNote> perfumeNoteList = perfumeNoteDomainService.getAllByPerfumeIds(perfumeIdList);
 
         return new Result(perfumeNoteList);
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
@@ -8,4 +8,6 @@ public interface PerfumeDomainService {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
 
+    List<Perfume> findByUserPreferenceNotes(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
@@ -8,6 +8,6 @@ public interface PerfumeDomainService {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
 
-    List<Perfume> findByUserPreferenceNotes(Long userId);
+    List<Perfume> findUserPreferenceNotesByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
@@ -8,6 +8,6 @@ public interface PerfumeDomainService {
 
     List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList);
 
-    List<Perfume> findUserPreferenceNotesByUserId(Long userId);
+    List<Perfume> findByUserPreferenceNotes(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeNoteDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeNoteDomainService.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface PerfumeNoteDomainService {
 
-    List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeId);
+    List<PerfumeNote> getAllByPerfumeIds(List<Long> perfumeId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeNoteDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeNoteDomainService.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.perfume.service.domain;
+
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import java.util.List;
+
+public interface PerfumeNoteDomainService {
+
+    List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeId);
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeNoteDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeNoteDomainServiceImpl.java
@@ -14,8 +14,8 @@ public class PerfumeNoteDomainServiceImpl implements PerfumeNoteDomainService {
     private final PerfumeNoteRepository perfumeNoteRepository;
 
     @Override
-    public List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeList) {
-        return perfumeNoteRepository.getByPerfumeIdList(perfumeList);
+    public List<PerfumeNote> getAllByPerfumeIds(List<Long> perfumeList) {
+        return perfumeNoteRepository.getAllByPerfumeIds(perfumeList);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeNoteDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeNoteDomainServiceImpl.java
@@ -1,0 +1,21 @@
+package com.pikachu.purple.application.perfume.service.domain.impl;
+
+import com.pikachu.purple.application.perfume.port.out.PerfumeNoteRepository;
+import com.pikachu.purple.application.perfume.service.domain.PerfumeNoteDomainService;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PerfumeNoteDomainServiceImpl implements PerfumeNoteDomainService {
+
+    private final PerfumeNoteRepository perfumeNoteRepository;
+
+    @Override
+    public List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeList) {
+        return perfumeNoteRepository.getByPerfumeIdList(perfumeList);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
@@ -20,8 +20,8 @@ public class PerfumeServiceImpl implements PerfumeDomainService {
     }
 
     @Override
-    public List<Perfume> findByUserPreferenceNotes(Long userId) {
-        return perfumeRepository.findByUserPreferenceNotes(userId);
+    public List<Perfume> findUserPreferenceNotesByUserId(Long userId) {
+        return perfumeRepository.findUserPreferenceNotesByUserId(userId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
@@ -19,4 +19,9 @@ public class PerfumeServiceImpl implements PerfumeDomainService {
         return perfumeRepository.findByPerfumeBrands(brandList);
     }
 
+    @Override
+    public List<Perfume> findByUserPreferenceNotes(Long userId) {
+        return perfumeRepository.findByUserPreferenceNotes(userId);
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeServiceImpl.java
@@ -20,8 +20,8 @@ public class PerfumeServiceImpl implements PerfumeDomainService {
     }
 
     @Override
-    public List<Perfume> findUserPreferenceNotesByUserId(Long userId) {
-        return perfumeRepository.findUserPreferenceNotesByUserId(userId);
+    public List<Perfume> findByUserPreferenceNotes(Long userId) {
+        return perfumeRepository.findByUserPreferenceNotes(userId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
@@ -12,20 +12,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class RecommendNotesProvider {
 
-    private static final Map<Double, Double> weightMap = new HashMap<>();
-
-    static{
-        weightMap.put(5.0, 1.0);
-        weightMap.put(4.5, 0.9);
-        weightMap.put(4.0, 0.8);
-        weightMap.put(3.5, 0.7);
-        weightMap.put(3.0, 0.0);
-        weightMap.put(2.5, 0.0);
-        weightMap.put(2.0, -0.7);
-        weightMap.put(1.5, -0.8);
-        weightMap.put(1.0, -0.9);
-        weightMap.put(0.5, -1.0);
-    }
+    private static final HashMap<Double, Double> weightMap = new HashMap<>() {{
+        put(5.0, 1.0);
+        put(4.5, 0.9);
+        put(4.0, 0.8);
+        put(3.5, 0.7);
+        put(3.0, 0.0);
+        put(2.5, 0.0);
+        put(2.0, -0.7);
+        put(1.5, -0.8);
+        put(1.0, -0.9);
+        put(0.5, -1.0);
+    }};
 
     public List<Note> getTopThreeNotes(
         List<Rating> ratingList,

--- a/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
@@ -1,0 +1,64 @@
+package com.pikachu.purple.application.perfume.util;
+
+import com.pikachu.purple.domain.note.Note;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.domain.rating.Rating;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecommendNotesProvider {
+
+    private static final Map<Double, Double> weightMap = new HashMap<>();
+
+    static{
+        weightMap.put(5.0, 1.0);
+        weightMap.put(4.5, 0.9);
+        weightMap.put(4.0, 0.8);
+        weightMap.put(3.5, 0.7);
+        weightMap.put(3.0, 0.0);
+        weightMap.put(2.5, 0.0);
+        weightMap.put(2.0, -0.7);
+        weightMap.put(1.5, -0.8);
+        weightMap.put(1.0, -0.9);
+        weightMap.put(0.5, -1.0);
+    }
+
+    public List<Note> getTopThreeNotes(
+        List<Rating> ratingList,
+        List<PerfumeNote> perfumeNoteList
+    ) {
+        Map<String, Double> noteScoreMap = new HashMap<>();
+
+        for (Rating rating : ratingList) {
+            Long perfumeId = rating.getPerfumeId();
+            Double score = rating.getScore();
+            Double weightedScore = convert(score);
+
+            for (PerfumeNote note : perfumeNoteList) {
+                if (note.getPerfumeId().equals(perfumeId)) {
+                    noteScoreMap.merge(
+                        note.getNoteName(),
+                        weightedScore,
+                        Double::sum
+                    );
+                }
+            }
+        }
+
+        return noteScoreMap.entrySet().stream()
+            .sorted(Map.Entry.<String, Double>comparingByValue().reversed())
+            .limit(3)
+            .map(entry -> new Note(entry.getKey()))
+            .collect(Collectors.toList());
+    }
+
+    private double convert(double score){
+        double weight = weightMap.get(score);
+        return score * weight;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingGetByUserIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingGetByUserIdUseCase.java
@@ -7,7 +7,7 @@ public interface RatingGetByUserIdUseCase {
 
     Result invoke(Long userId);
 
-    record Result(List<Rating> ratingList){
+    record Result(List<Rating> ratingList) {
 
     }
 

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingGetByUserIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingGetByUserIdUseCase.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.rating.port.in;
+
+import com.pikachu.purple.domain.rating.Rating;
+import java.util.List;
+
+public interface RatingGetByUserIdUseCase {
+
+    Result invoke(Long userId);
+
+    record Result(List<Rating> ratingList){
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
@@ -7,4 +7,6 @@ public interface RatingRepository {
 
     void create(List<Rating> ratingList);
 
+    List<Rating> getByUserId(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
@@ -7,6 +7,6 @@ public interface RatingRepository {
 
     void create(List<Rating> ratingList);
 
-    List<Rating> getByUserId(Long userId);
+    List<Rating> getAllByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingGetByUserIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingGetByUserIdApplicationService.java
@@ -15,7 +15,7 @@ public class RatingGetByUserIdApplicationService implements RatingGetByUserIdUse
 
     @Override
     public Result invoke(Long userId) {
-        List<Rating> ratingList = ratingDomainService.getByUserId(userId);
+        List<Rating> ratingList = ratingDomainService.getAllByUserId(userId);
 
         return new RatingGetByUserIdUseCase.Result(ratingList);
     }

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingGetByUserIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingGetByUserIdApplicationService.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.rating.service.application;
+
+import com.pikachu.purple.application.rating.port.in.RatingGetByUserIdUseCase;
+import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
+import com.pikachu.purple.domain.rating.Rating;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RatingGetByUserIdApplicationService implements RatingGetByUserIdUseCase {
+
+    private final RatingDomainService ratingDomainService;
+
+    @Override
+    public Result invoke(Long userId) {
+        List<Rating> ratingList = ratingDomainService.getByUserId(userId);
+
+        return new RatingGetByUserIdUseCase.Result(ratingList);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
@@ -15,14 +15,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RatingSaveApplicationService implements RatingSaveUseCase {
 
-    private static final int ZERO = 0;
     private final RatingDomainService ratingDomainService;
     private final UserPreferenceNoteSaveUseCase userPreferenceNoteSaveUseCase;
 
     @Transactional
     @Override
     public void invoke(Command command) {
-        List<Long> ratingIdList = IntStream.range(ZERO, command.ratingValueList().size())
+        List<Long> ratingIdList = IntStream.range(0, command.ratingValueList().size())
             .mapToObj(i -> IdGenerator.generate())
             .collect(Collectors.toList());
 

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.application.rating.service.application;
 
 import com.pikachu.purple.application.rating.port.in.RatingSaveUseCase;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
+import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteSaveUseCase;
 import com.pikachu.purple.application.util.IdGenerator;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -16,6 +17,7 @@ public class RatingSaveApplicationService implements RatingSaveUseCase {
 
     private static final int ZERO = 0;
     private final RatingDomainService ratingDomainService;
+    private final UserPreferenceNoteSaveUseCase userPreferenceNoteSaveUseCase;
 
     @Transactional
     @Override
@@ -29,6 +31,8 @@ public class RatingSaveApplicationService implements RatingSaveUseCase {
             command.userId(),
             command.ratingValueList()
         );
+
+        userPreferenceNoteSaveUseCase.invoke();
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
@@ -12,6 +12,6 @@ public interface RatingDomainService {
         List<RatingValue> ratingValueList
     );
 
-    List<Rating> getByUserId(Long userId);
+    List<Rating> getAllByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
@@ -1,6 +1,7 @@
 package com.pikachu.purple.application.rating.service.domain;
 
 import com.pikachu.purple.bootstrap.user.vo.RatingValue;
+import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
 public interface RatingDomainService {
@@ -10,5 +11,7 @@ public interface RatingDomainService {
         Long userId,
         List<RatingValue> ratingValueList
     );
+
+    List<Rating> getByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
@@ -36,10 +36,8 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     }
 
     @Override
-    public List<Rating> getByUserId(Long userId) {
-        List<Rating> ratingList = ratingRepository.getByUserId(userId);
-
-        return ratingList;
+    public List<Rating> getAllByUserId(Long userId) {
+        return ratingRepository.getAllByUserId(userId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
@@ -35,4 +35,11 @@ public class RatingDomainServiceImpl implements RatingDomainService {
         ratingRepository.create(ratingList);
     }
 
+    @Override
+    public List<Rating> getByUserId(Long userId) {
+        List<Rating> ratingList = ratingRepository.getByUserId(userId);
+
+        return ratingList;
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/in/UserPreferenceNoteGetUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/in/UserPreferenceNoteGetUseCase.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.userPreferenceNote.port.in;
+
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import java.util.List;
+
+public interface UserPreferenceNoteGetUseCase {
+
+    Result invoke();
+
+    record Result(List<UserPreferenceNote> userPreferenceNoteList){
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/in/UserPreferenceNoteSaveUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/in/UserPreferenceNoteSaveUseCase.java
@@ -1,0 +1,7 @@
+package com.pikachu.purple.application.userPreferenceNote.port.in;
+
+public interface UserPreferenceNoteSaveUseCase {
+
+    void invoke();
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/out/UserPreferenceNoteRepository.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/port/out/UserPreferenceNoteRepository.java
@@ -1,0 +1,12 @@
+package com.pikachu.purple.application.userPreferenceNote.port.out;
+
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import java.util.List;
+
+public interface UserPreferenceNoteRepository {
+
+    void save(List<UserPreferenceNote> userPreferenceNoteList);
+
+    List<UserPreferenceNote> getByUserId(Long userId);
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.application.userPreferenceNote.service.application;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteGetUseCase;
 import com.pikachu.purple.application.userPreferenceNote.service.domain.UserPreferenceNoteDomainService;
 import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
@@ -15,7 +17,8 @@ public class UserPreferenceNoteGetApplicationService implements UserPreferenceNo
 
     @Override
     public Result invoke() {
-        List<UserPreferenceNote> userPreferenceNoteList = userPreferenceNoteDomainService.getByUserId(1L);
+        List<UserPreferenceNote> userPreferenceNoteList = userPreferenceNoteDomainService.getByUserId(
+            getCurrentUserAuthentication().userId());
 
         return new Result(userPreferenceNoteList);
     }

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
@@ -17,8 +17,8 @@ public class UserPreferenceNoteGetApplicationService implements UserPreferenceNo
 
     @Override
     public Result invoke() {
-        List<UserPreferenceNote> userPreferenceNoteList = userPreferenceNoteDomainService.getByUserId(
-            getCurrentUserAuthentication().userId());
+        Long userId = getCurrentUserAuthentication().userId();
+        List<UserPreferenceNote> userPreferenceNoteList = userPreferenceNoteDomainService.getByUserId(userId);
 
         return new Result(userPreferenceNoteList);
     }

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteGetApplicationService.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.userPreferenceNote.service.application;
+
+import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteGetUseCase;
+import com.pikachu.purple.application.userPreferenceNote.service.domain.UserPreferenceNoteDomainService;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceNoteGetApplicationService implements UserPreferenceNoteGetUseCase {
+
+    private final UserPreferenceNoteDomainService userPreferenceNoteDomainService;
+
+    @Override
+    public Result invoke() {
+        List<UserPreferenceNote> userPreferenceNoteList = userPreferenceNoteDomainService.getByUserId(1L);
+
+        return new Result(userPreferenceNoteList);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteSaveApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteSaveApplicationService.java
@@ -1,0 +1,52 @@
+package com.pikachu.purple.application.userPreferenceNote.service.application;
+
+import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteSaveUseCase;
+import com.pikachu.purple.application.perfume.port.in.PerfumeNoteGetByRatingsUseCase;
+import com.pikachu.purple.application.perfume.util.RecommendNotesProvider;
+import com.pikachu.purple.application.rating.port.in.RatingGetByUserIdUseCase;
+import com.pikachu.purple.application.userPreferenceNote.service.domain.UserPreferenceNoteDomainService;
+import com.pikachu.purple.application.util.IdGenerator;
+import com.pikachu.purple.domain.note.Note;
+import com.pikachu.purple.domain.rating.Rating;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceNoteSaveApplicationService implements
+    UserPreferenceNoteSaveUseCase {
+
+    private final RatingGetByUserIdUseCase ratingGetByUserIdUseCase;
+    private final PerfumeNoteGetByRatingsUseCase perfumeNoteGetByRatingsUseCase;
+    private final RecommendNotesProvider recommendNotesProvider;
+    private final UserPreferenceNoteDomainService userPreferenceNoteDomainService;
+
+    @Override
+    public void invoke() {
+        RatingGetByUserIdUseCase.Result ratingResult = ratingGetByUserIdUseCase.invoke(1L);
+
+        List<Long> perfumeIdList = ratingResult.ratingList().stream()
+            .map(Rating::getPerfumeId)
+            .toList();
+
+        PerfumeNoteGetByRatingsUseCase.Result perfumeNoteResult = perfumeNoteGetByRatingsUseCase.invoke(perfumeIdList);
+
+        List<Note> topThreeNoteList = recommendNotesProvider.getTopThreeNotes(
+            ratingResult.ratingList(),
+            perfumeNoteResult.perfumeNoteList()
+        );
+
+        List<Long> userPreferenceNoteIdList = IntStream.range(0, topThreeNoteList.size())
+                .mapToObj(i -> IdGenerator.generate())
+                .toList();
+
+        userPreferenceNoteDomainService.save(
+            userPreferenceNoteIdList,
+            1L,
+            topThreeNoteList
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteSaveApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteSaveApplicationService.java
@@ -36,19 +36,19 @@ public class UserPreferenceNoteSaveApplicationService implements
 
         PerfumeNoteGetByPerfumeIdListUseCase.Result perfumeNoteResult = perfumeNoteGetByRatingsUseCase.invoke(perfumeIdList);
 
-        List<Note> topThreeNoteList = recommendNotesProvider.getTopThreeNotes(
+        List<Note> topThreeNotes = recommendNotesProvider.getTopThreeNotes(
             ratingResult.ratingList(),
             perfumeNoteResult.perfumeNoteList()
         );
 
-        List<Long> userPreferenceNoteIdList = IntStream.range(0, topThreeNoteList.size())
+        List<Long> userPreferenceNoteIdList = IntStream.range(0, topThreeNotes.size())
                 .mapToObj(i -> IdGenerator.generate())
                 .toList();
 
         userPreferenceNoteDomainService.save(
             userPreferenceNoteIdList,
             userId,
-            topThreeNoteList
+            topThreeNotes
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/domain/UserPreferenceNoteDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/domain/UserPreferenceNoteDomainService.java
@@ -1,0 +1,18 @@
+package com.pikachu.purple.application.userPreferenceNote.service.domain;
+
+import com.pikachu.purple.domain.note.Note;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import java.util.List;
+
+public interface UserPreferenceNoteDomainService {
+
+    void save(
+        List<Long> userPreferenceNoteIdList,
+        Long userId,
+        List<Note> perfumeNoteList
+    );
+
+    List<UserPreferenceNote> getByUserId(Long userId);
+
+}

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/domain/impl/UserPreferenceNoteDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/domain/impl/UserPreferenceNoteDomainServiceImpl.java
@@ -1,0 +1,41 @@
+package com.pikachu.purple.application.userPreferenceNote.service.domain.impl;
+
+import com.pikachu.purple.application.userPreferenceNote.port.out.UserPreferenceNoteRepository;
+import com.pikachu.purple.application.userPreferenceNote.service.domain.UserPreferenceNoteDomainService;
+import com.pikachu.purple.domain.note.Note;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPreferenceNoteDomainServiceImpl implements UserPreferenceNoteDomainService {
+
+    private final UserPreferenceNoteRepository userPreferenceNoteRepository;
+
+    @Override
+    public void save(
+        List<Long> userPreferenceNoteIdList,
+        Long userId,
+        List<Note> noteList
+    ) {
+       List<UserPreferenceNote> userPreferenceNoteList = IntStream.range(0, userPreferenceNoteIdList.size())
+               .mapToObj(i -> UserPreferenceNote.builder()
+                   .id(userPreferenceNoteIdList.get(i))
+                   .userId(userId)
+                   .noteName(noteList.get(i).getNoteName())
+                   .build())
+           .collect(Collectors.toList());
+
+        userPreferenceNoteRepository.save(userPreferenceNoteList);
+    }
+
+    @Override
+    public List<UserPreferenceNote> getByUserId(Long userId) {
+        return userPreferenceNoteRepository.getByUserId(userId);
+    }
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
@@ -21,6 +21,7 @@ public interface PerfumeApi {
     @ResponseStatus(HttpStatus.OK)
     GetPerfumeByBrandsResponse getPerfumeByBrands(@RequestBody GetPerfumeByBrandsRequest request);
 
+    @Secured
     @Operation(summary = "선호노트 기반 추천 향수 리스트 조회")
     @GetMapping("/preference-based/recommend")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
@@ -1,7 +1,9 @@
 package com.pikachu.purple.bootstrap.perfume.api;
 
+import com.pikachu.purple.bootstrap.common.security.Secured;
 import com.pikachu.purple.bootstrap.perfume.dto.request.GetPerfumeByBrandsRequest;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByBrandsResponse;
+import com.pikachu.purple.bootstrap.perfume.dto.response.GetPreferenceBasedRecommendResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
@@ -18,5 +20,10 @@ public interface PerfumeApi {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     GetPerfumeByBrandsResponse getPerfumeByBrands(@RequestBody GetPerfumeByBrandsRequest request);
+
+    @Operation(summary = "선호노트 기반 추천 향수 리스트 조회")
+    @GetMapping("/preference-based/recommend")
+    @ResponseStatus(HttpStatus.OK)
+    GetPreferenceBasedRecommendResponse getPreferenceBasedRecommend();
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
@@ -23,7 +23,7 @@ public interface PerfumeApi {
 
     @Secured
     @Operation(summary = "선호노트 기반 추천 향수 리스트 조회")
-    @GetMapping("/preference-based/recommend")
+    @GetMapping("/prefer-note")
     @ResponseStatus(HttpStatus.OK)
     GetPreferenceBasedRecommendResponse getPreferenceBasedRecommend();
 

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -3,7 +3,6 @@ package com.pikachu.purple.bootstrap.perfume.controller;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase.Command;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByUserPreferenceNoteUseCase;
-import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteSaveUseCase;
 import com.pikachu.purple.bootstrap.perfume.api.PerfumeApi;
 import com.pikachu.purple.bootstrap.perfume.dto.request.GetPerfumeByBrandsRequest;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByBrandsResponse;
@@ -29,7 +28,10 @@ public class PerfumeController implements PerfumeApi {
     public GetPreferenceBasedRecommendResponse getPreferenceBasedRecommend() {
         PerfumeGetByUserPreferenceNoteUseCase.Result result = perfumeGetByUserPreferenceNoteUseCase.invoke();
 
-        return new GetPreferenceBasedRecommendResponse(result.perfumeList());
+        return new GetPreferenceBasedRecommendResponse(
+            result.userPreferenceNoteList(),
+            result.perfumeList()
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -2,10 +2,12 @@ package com.pikachu.purple.bootstrap.perfume.controller;
 
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase.Command;
-import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase.Result;
+import com.pikachu.purple.application.perfume.port.in.PerfumeGetByUserPreferenceNoteUseCase;
+import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteSaveUseCase;
 import com.pikachu.purple.bootstrap.perfume.api.PerfumeApi;
 import com.pikachu.purple.bootstrap.perfume.dto.request.GetPerfumeByBrandsRequest;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByBrandsResponse;
+import com.pikachu.purple.bootstrap.perfume.dto.response.GetPreferenceBasedRecommendResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,12 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class PerfumeController implements PerfumeApi {
 
     private final PerfumeGetByBrandsUseCase perfumeGetByBrandsUseCase;
+    private final PerfumeGetByUserPreferenceNoteUseCase perfumeGetByUserPreferenceNoteUseCase;
 
     @Override
     public GetPerfumeByBrandsResponse getPerfumeByBrands(GetPerfumeByBrandsRequest request) {
-        Result result = perfumeGetByBrandsUseCase.invoke(new Command(request.brandList()));
+        PerfumeGetByBrandsUseCase.Result result = perfumeGetByBrandsUseCase.invoke(new Command(request.brandList()));
 
         return new GetPerfumeByBrandsResponse(result.perfumeList());
+    }
+
+    @Override
+    public GetPreferenceBasedRecommendResponse getPreferenceBasedRecommend() {
+        PerfumeGetByUserPreferenceNoteUseCase.Result result = perfumeGetByUserPreferenceNoteUseCase.invoke();
+
+        return new GetPreferenceBasedRecommendResponse(result.perfumeList());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetPreferenceBasedRecommendResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetPreferenceBasedRecommendResponse.java
@@ -1,0 +1,7 @@
+package com.pikachu.purple.bootstrap.perfume.dto.response;
+
+import com.pikachu.purple.domain.perfume.Perfume;
+import java.util.List;
+
+public record GetPreferenceBasedRecommendResponse(List<Perfume> perfumeList) {
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetPreferenceBasedRecommendResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetPreferenceBasedRecommendResponse.java
@@ -1,7 +1,12 @@
 package com.pikachu.purple.bootstrap.perfume.dto.response;
 
 import com.pikachu.purple.domain.perfume.Perfume;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
 import java.util.List;
 
-public record GetPreferenceBasedRecommendResponse(List<Perfume> perfumeList) {
+public record GetPreferenceBasedRecommendResponse(
+    List<UserPreferenceNote> userPreferenceNoteList,
+    List<Perfume> perfumeList
+) {
+
 }

--- a/src/main/java/com/pikachu/purple/domain/note/Note.java
+++ b/src/main/java/com/pikachu/purple/domain/note/Note.java
@@ -1,0 +1,19 @@
+package com.pikachu.purple.domain.note;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Note {
+
+    private String noteName;
+
+    @Builder
+    public Note(String noteName){
+        this.noteName = noteName;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
+++ b/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
@@ -1,0 +1,35 @@
+package com.pikachu.purple.domain.perfume;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PerfumeNote {
+
+    private Long perfumeNoteId;
+    private Long perfumeId;
+    private String noteName;
+
+    @Builder
+    public PerfumeNote(
+        Long perfumeNoteId,
+        Long perfumeId,
+        String noteName
+    ) {
+        this.perfumeNoteId = perfumeNoteId;
+        this.perfumeId = perfumeId;
+        this.noteName = noteName;
+    }
+
+    @Override
+    public String toString() {
+        return "PerfumeNote{" +
+            "perfumeId=" + perfumeId +
+            ", noteName='" + noteName + '\'' +
+            '}';
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
+++ b/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
@@ -24,12 +24,4 @@ public class PerfumeNote {
         this.noteName = noteName;
     }
 
-    @Override
-    public String toString() {
-        return "PerfumeNote{" +
-            "perfumeId=" + perfumeId +
-            ", noteName='" + noteName + '\'' +
-            '}';
-    }
-
 }

--- a/src/main/java/com/pikachu/purple/domain/user/entity/UserPreferenceNote.java
+++ b/src/main/java/com/pikachu/purple/domain/user/entity/UserPreferenceNote.java
@@ -1,0 +1,27 @@
+package com.pikachu.purple.domain.user.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreferenceNote {
+
+    private Long id;
+    private Long userId;
+    private String noteName;
+
+    @Builder
+    public UserPreferenceNote(
+        Long id,
+        Long userId,
+        String noteName
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.noteName = noteName;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/note/entity/NoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/note/entity/NoteJpaEntity.java
@@ -1,0 +1,21 @@
+package com.pikachu.purple.infrastructure.persistence.note.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "note")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoteJpaEntity {
+
+    @Id
+    @Column(name = "note_name")
+    private String noteName;
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/note/entity/NoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/note/entity/NoteJpaEntity.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class NoteJpaEntity {
 
     @Id
-    @Column(name = "note_name")
+    @Column(name = "name")
     private String noteName;
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -3,7 +3,6 @@ package com.pikachu.purple.infrastructure.persistence.perfume.adaptor;
 import com.pikachu.purple.application.perfume.port.out.PerfumeRepository;
 import com.pikachu.purple.domain.perfume.Perfume;
 import com.pikachu.purple.domain.perfume.PerfumeBrand;
-import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
 import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeJpaEntity;
 import com.pikachu.purple.infrastructure.persistence.perfume.repository.PerfumeJpaRepository;
 import java.util.List;
@@ -33,9 +32,9 @@ public class PerfumeJpaAdaptor implements PerfumeRepository {
     }
 
     @Override
-    public List<Perfume> findByUserPreferenceNotes(Long userId) {
+    public List<Perfume> findUserPreferenceNotesByUserId(Long userId) {
         PageRequest pageRequest = PageRequest.of(ZERO, THIRTY);
-        List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findByUserPreferenceNotes(
+        List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findUserPreferenceNotesByUserId(
             userId,
             pageRequest
         ).getContent();

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -15,8 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PerfumeJpaAdaptor implements PerfumeRepository {
 
-    private final static int ZERO = 0;
-    private final static int THIRTY = 30;
+    private final static int MAX_SIZE = 30;
     private final PerfumeJpaRepository perfumeJpaRepository;
 
     public List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList) {
@@ -33,7 +32,7 @@ public class PerfumeJpaAdaptor implements PerfumeRepository {
 
     @Override
     public List<Perfume> findByUserPreferenceNotes(Long userId) {
-        PageRequest pageRequest = PageRequest.of(ZERO, THIRTY);
+        PageRequest pageRequest = PageRequest.of(0, MAX_SIZE);
         List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findByUserPreferenceNotes(
             userId,
             pageRequest

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -32,9 +32,9 @@ public class PerfumeJpaAdaptor implements PerfumeRepository {
     }
 
     @Override
-    public List<Perfume> findUserPreferenceNotesByUserId(Long userId) {
+    public List<Perfume> findByUserPreferenceNotes(Long userId) {
         PageRequest pageRequest = PageRequest.of(ZERO, THIRTY);
-        List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findUserPreferenceNotesByUserId(
+        List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findByUserPreferenceNotes(
             userId,
             pageRequest
         ).getContent();

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -3,17 +3,21 @@ package com.pikachu.purple.infrastructure.persistence.perfume.adaptor;
 import com.pikachu.purple.application.perfume.port.out.PerfumeRepository;
 import com.pikachu.purple.domain.perfume.Perfume;
 import com.pikachu.purple.domain.perfume.PerfumeBrand;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
 import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeJpaEntity;
 import com.pikachu.purple.infrastructure.persistence.perfume.repository.PerfumeJpaRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class PerfumeJpaAdaptor implements PerfumeRepository {
 
+    private final static int ZERO = 0;
+    private final static int THIRTY = 30;
     private final PerfumeJpaRepository perfumeJpaRepository;
 
     public List<Perfume> findByPerfumeBrands(List<PerfumeBrand> brandList) {
@@ -22,6 +26,19 @@ public class PerfumeJpaAdaptor implements PerfumeRepository {
             .toList();
 
         List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findByBrandNameIn(brandNames);
+
+        return perfumeJpaEntityList.stream()
+            .map(PerfumeJpaEntity::toDomain)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Perfume> findByUserPreferenceNotes(Long userId) {
+        PageRequest pageRequest = PageRequest.of(ZERO, THIRTY);
+        List<PerfumeJpaEntity> perfumeJpaEntityList = perfumeJpaRepository.findByUserPreferenceNotes(
+            userId,
+            pageRequest
+        ).getContent();
 
         return perfumeJpaEntityList.stream()
             .map(PerfumeJpaEntity::toDomain)

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeNoteJpaEntityAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeNoteJpaEntityAdaptor.java
@@ -16,7 +16,7 @@ public class PerfumeNoteJpaEntityAdaptor implements PerfumeNoteRepository {
     private final PerfumeNoteJpaRepository perfumeNoteJpaRepository;
 
     @Override
-    public List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeIdList) {
+    public List<PerfumeNote> getAllByPerfumeIds(List<Long> perfumeIdList) {
         List<PerfumeNoteJpaEntity> perfumeNoteJpaEntityList = perfumeNoteJpaRepository.findByPerfumeIdIn(perfumeIdList);
 
         return perfumeNoteJpaEntityList.stream()

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeNoteJpaEntityAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeNoteJpaEntityAdaptor.java
@@ -1,0 +1,27 @@
+package com.pikachu.purple.infrastructure.persistence.perfume.adaptor;
+
+import com.pikachu.purple.application.perfume.port.out.PerfumeNoteRepository;
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeNoteJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.perfume.repository.PerfumeNoteJpaRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PerfumeNoteJpaEntityAdaptor implements PerfumeNoteRepository {
+
+    private final PerfumeNoteJpaRepository perfumeNoteJpaRepository;
+
+    @Override
+    public List<PerfumeNote> getByPerfumeIdList(List<Long> perfumeIdList) {
+        List<PerfumeNoteJpaEntity> perfumeNoteJpaEntityList = perfumeNoteJpaRepository.findByPerfumeIdIn(perfumeIdList);
+
+        return perfumeNoteJpaEntityList.stream()
+            .map(PerfumeNoteJpaEntity::toDomain)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
@@ -22,7 +22,7 @@ public class PerfumeNoteJpaEntity {
     @Column(name = "perfume_id")
     private Long perfumeId;
 
-    @Column(name = "noteName")
+    @Column(name = "note_name")
     private String noteName;
 
     public static PerfumeNote toDomain(PerfumeNoteJpaEntity perfumeNoteJpaEntity) {

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
@@ -1,0 +1,36 @@
+package com.pikachu.purple.infrastructure.persistence.perfume.entity;
+
+import com.pikachu.purple.domain.perfume.PerfumeNote;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "perfume_note")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PerfumeNoteJpaEntity {
+
+    @Id
+    @Column(name = "perfume_note_id")
+    private Long perfumeNoteId;
+
+    @Column(name = "perfume_id")
+    private Long perfumeId;
+
+    @Column(name = "noteName")
+    private String noteName;
+
+    public static PerfumeNote toDomain(PerfumeNoteJpaEntity perfumeNoteJpaEntity) {
+        return PerfumeNote.builder()
+            .perfumeNoteId(perfumeNoteJpaEntity.getPerfumeNoteId())
+            .perfumeId(perfumeNoteJpaEntity.getPerfumeId())
+            .noteName(perfumeNoteJpaEntity.getNoteName())
+            .build();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
@@ -25,6 +25,6 @@ public interface PerfumeJpaRepository extends JpaRepository<PerfumeJpaEntity, Lo
         "GROUP BY p.perfume_id " +
         "ORDER BY COUNT(pn.perfume_note_id) DESC ",
         nativeQuery = true)
-    Page<PerfumeJpaEntity> findUserPreferenceNotesByUserId(@Param("userId") Long userId, Pageable pageable);
+    Page<PerfumeJpaEntity> findByUserPreferenceNotes(@Param("userId") Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
@@ -2,8 +2,11 @@ package com.pikachu.purple.infrastructure.persistence.perfume.repository;
 
 import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeJpaEntity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,5 +16,15 @@ public interface PerfumeJpaRepository extends JpaRepository<PerfumeJpaEntity, Lo
         "SELECT * FROM perfume p INNER JOIN perfume_brand pb ON p.p_brand_name = pb.brand_name WHERE p.p_brand_name IN :brandList",
         nativeQuery = true)
     List<PerfumeJpaEntity> findByBrandNameIn(List<String> brandList);
+
+
+    @Query(value = "SELECT p.* FROM perfume p " +
+        "INNER JOIN perfume_note pn ON p.perfume_id = pn.perfume_id " +
+        "WHERE pn.note_name IN (" +
+        "SELECT upn.note_name FROM user_preference_note upn WHERE upn.user_id = :userId) " +
+        "GROUP BY p.perfume_id " +
+        "ORDER BY COUNT(pn.perfume_note_id) DESC ",
+        nativeQuery = true)
+    Page<PerfumeJpaEntity> findByUserPreferenceNotes(@Param("userId") Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
@@ -25,6 +25,6 @@ public interface PerfumeJpaRepository extends JpaRepository<PerfumeJpaEntity, Lo
         "GROUP BY p.perfume_id " +
         "ORDER BY COUNT(pn.perfume_note_id) DESC ",
         nativeQuery = true)
-    Page<PerfumeJpaEntity> findByUserPreferenceNotes(@Param("userId") Long userId, Pageable pageable);
+    Page<PerfumeJpaEntity> findUserPreferenceNotesByUserId(@Param("userId") Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeNoteJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeNoteJpaRepository.java
@@ -1,0 +1,13 @@
+package com.pikachu.purple.infrastructure.persistence.perfume.repository;
+
+import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeNoteJpaEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerfumeNoteJpaRepository extends JpaRepository<PerfumeNoteJpaEntity, Long> {
+
+    List<PerfumeNoteJpaEntity> findByPerfumeIdIn(List<Long> perfumeIdList);
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
@@ -25,7 +25,7 @@ public class RatingJpaAdaptor implements RatingRepository {
     }
 
     @Override
-    public List<Rating> getByUserId(Long userId) {
+    public List<Rating> getAllByUserId(Long userId) {
         List<RatingJpaEntity> ratingJpaEntities = ratingJpaRepository.findByUserId(userId);
 
         return ratingJpaEntities.stream()

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
@@ -5,6 +5,7 @@ import com.pikachu.purple.domain.rating.Rating;
 import com.pikachu.purple.infrastructure.persistence.rating.entity.RatingJpaEntity;
 import com.pikachu.purple.infrastructure.persistence.rating.repository.RatingJpaRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,15 @@ public class RatingJpaAdaptor implements RatingRepository {
             .toList();
 
         ratingJpaRepository.saveAll(ratingJpaEntities);
+    }
+
+    @Override
+    public List<Rating> getByUserId(Long userId) {
+        List<RatingJpaEntity> ratingJpaEntities = ratingJpaRepository.findByUserId(userId);
+
+        return ratingJpaEntities.stream()
+            .map(RatingJpaEntity::toDomain)
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
@@ -1,9 +1,15 @@
 package com.pikachu.purple.infrastructure.persistence.rating.repository;
 
 import com.pikachu.purple.infrastructure.persistence.rating.entity.RatingJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RatingJpaRepository extends JpaRepository<RatingJpaEntity, Long> {
+
+    @Query("SELECT r FROM RatingJpaEntity r WHERE r.userId = :userId")
+    List<RatingJpaEntity> findByUserId(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RatingJpaRepository extends JpaRepository<RatingJpaEntity, Long> {
 
-    @Query("SELECT r FROM RatingJpaEntity r WHERE r.userId = :userId")
     List<RatingJpaEntity> findByUserId(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/adaptor/UserPreferenceNoteAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/adaptor/UserPreferenceNoteAdaptor.java
@@ -1,0 +1,35 @@
+package com.pikachu.purple.infrastructure.persistence.userPreferenceNote.adaptor;
+
+import com.pikachu.purple.application.userPreferenceNote.port.out.UserPreferenceNoteRepository;
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import com.pikachu.purple.infrastructure.persistence.userPreferenceNote.entity.UserPreferenceNoteJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.userPreferenceNote.repository.UserPreferenceNoteJpaRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserPreferenceNoteAdaptor implements UserPreferenceNoteRepository {
+
+    private final UserPreferenceNoteJpaRepository userPreferenceNoteJpaRepository;
+
+    @Override
+    public void save(List<UserPreferenceNote> userPreferenceNoteList) {
+        List<UserPreferenceNoteJpaEntity> userPreferenceNoteJpaEntityList = userPreferenceNoteList.stream()
+            .map(UserPreferenceNoteJpaEntity::toJpaEntity)
+            .toList();
+
+        userPreferenceNoteJpaRepository.saveAll(userPreferenceNoteJpaEntityList);
+    }
+
+    @Override
+    public List<UserPreferenceNote> getByUserId(Long userId) {
+        List<UserPreferenceNoteJpaEntity> userPreferenceNoteJpaEntityList = userPreferenceNoteJpaRepository.findByUserId(userId);
+        return userPreferenceNoteJpaEntityList.stream()
+            .map(UserPreferenceNoteJpaEntity::toDomain)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/entity/UserPreferenceNoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/entity/UserPreferenceNoteJpaEntity.java
@@ -1,0 +1,56 @@
+package com.pikachu.purple.infrastructure.persistence.userPreferenceNote.entity;
+
+import com.pikachu.purple.domain.user.entity.UserPreferenceNote;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_preference_note")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPreferenceNoteJpaEntity {
+
+    @Id
+    @Column(name = "user_preference_note_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "note_name", nullable = false)
+    private String noteName;
+
+    @Builder
+    public UserPreferenceNoteJpaEntity(
+        Long id,
+        Long userId,
+        String noteName
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.noteName = noteName;
+    }
+
+    public static UserPreferenceNoteJpaEntity toJpaEntity(UserPreferenceNote userPreferenceNote){
+        return UserPreferenceNoteJpaEntity.builder()
+            .id(userPreferenceNote.getId())
+            .userId(userPreferenceNote.getUserId())
+            .noteName(userPreferenceNote.getNoteName())
+            .build();
+    }
+
+    public static UserPreferenceNote toDomain(UserPreferenceNoteJpaEntity userPreferenceNoteJpaEntity){
+        return UserPreferenceNote.builder()
+            .id(userPreferenceNoteJpaEntity.getId())
+            .userId(userPreferenceNoteJpaEntity.getUserId())
+            .noteName(userPreferenceNoteJpaEntity.getNoteName())
+            .build();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/repository/UserPreferenceNoteJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/userPreferenceNote/repository/UserPreferenceNoteJpaRepository.java
@@ -1,0 +1,16 @@
+package com.pikachu.purple.infrastructure.persistence.userPreferenceNote.repository;
+
+import com.pikachu.purple.infrastructure.persistence.userPreferenceNote.entity.UserPreferenceNoteJpaEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserPreferenceNoteJpaRepository extends JpaRepository<UserPreferenceNoteJpaEntity, Long> {
+
+    @Query("SELECT upn FROM UserPreferenceNoteJpaEntity upn WHERE upn.userId = :userId")
+    List<UserPreferenceNoteJpaEntity> findByUserId(@Param("userId") Long userId);
+
+}


### PR DESCRIPTION
### 진행상황
- 온보딩에서 저장한 별점을 이용하여, 추천 알고리즘을 통해 top3 노트를 추출하였습니다.
- 추출한 노트를 UserPrefereneNote Entity에 저장하였습니다.
- 저장한 노트를 기반으로 추천 향수들을 조회합니다. (현재 노트를 가장 많이 포함된 향수들을 DESC로 정렬하여 최대 30개까지 조회합니다)
- 아직 comment 부분은 미구현으로 추후에 리팩토링 할 예정입니다.