### PR TITLE
[PURPLE-105] 로그인 API 응답값 통일

### DIFF
--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -4,6 +4,7 @@ import com.auth0.jwk.JwkException;
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
+import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,7 +26,7 @@ public interface AuthApi {
     @Operation(summary = "소셜 로그인 URI 발급")
     @PostMapping("/login-try/{provider}")
     @ResponseStatus(HttpStatus.OK)
-    SocialLoginTryResponse socialLoginTry(
+    SuccessResponse<SocialLoginTryResponse> socialLoginTry(
         @PathVariable("provider") SocialLoginProvider provider
     ) throws URISyntaxException;
 
@@ -41,7 +42,7 @@ public interface AuthApi {
     @Operation(summary = "Jwt Token Refresh API")
     @PostMapping("/refresh")
     @ResponseStatus(HttpStatus.OK)
-    RefreshJwtTokenResponse refreshJwtToken(
+    SuccessResponse<RefreshJwtTokenResponse> refreshJwtToken(
         @RequestBody RefreshJwtTokenRequest request
     );
 

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -7,6 +7,7 @@ import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -30,7 +31,12 @@ public interface AuthApi {
         @PathVariable("provider") SocialLoginProvider provider
     ) throws URISyntaxException;
 
-    @Operation(summary = "소셜 로그인")
+    @Operation(summary = "소셜 로그인", responses = {
+        @ApiResponse(responseCode = "302", description =
+            "로그인 성공, jwt token query parameter를 담아 FE로 리디렉션되어 전달됩니다. \n\n"
+                + "**최종 redirect url : {client ip}/perpicks/auth/login/kakao/success?token={jwt token}**"
+        )
+    })
     @PostMapping("/login/{provider}")
     @ResponseStatus(HttpStatus.OK)
     void socialLogin(

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.pikachu.purple.bootstrap.auth.api.AuthApi;
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
+import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -24,13 +25,16 @@ public class AuthController implements AuthApi {
     private final RefreshJwtTokenUseCase refreshJwtTokenUseCase;
 
     @Override
-    public SocialLoginTryResponse socialLoginTry(SocialLoginProvider socialLoginProvider)
+    public SuccessResponse<SocialLoginTryResponse> socialLoginTry(
+        SocialLoginProvider socialLoginProvider)
         throws URISyntaxException {
         SocialLoginTryUseCase.Result result = socialLoginTryUseCase.invoke(
             new SocialLoginTryUseCase.Command(socialLoginProvider)
         );
 
-        return new SocialLoginTryResponse(result.socialLoginUrl());
+        return SuccessResponse.of(
+            new SocialLoginTryResponse(result.socialLoginUrl())
+        );
     }
 
     @Override
@@ -50,13 +54,16 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public RefreshJwtTokenResponse refreshJwtToken(RefreshJwtTokenRequest request) {
+    public SuccessResponse<RefreshJwtTokenResponse> refreshJwtToken(
+        RefreshJwtTokenRequest request) {
         RefreshJwtTokenUseCase.Result result = refreshJwtTokenUseCase.invoke(
             new RefreshJwtTokenUseCase.Command(
                 request.jwtToken()
             )
         );
 
-        return new RefreshJwtTokenResponse(result.jwtToken());
+        return SuccessResponse.of(
+            new RefreshJwtTokenResponse(result.jwtToken())
+        );
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,7 +58,7 @@ auth:
     response-type: code
     authorize-uri: https://kauth.kakao.com/oauth/authorize
     #    token-request-uri: https://kauth.kakao.com/oauth/token
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/perpicks/auth/login/kakao}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/perpicks/auth/login/kakao}
     jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
     login-success-uri: ${KAKAO_LOGIN_SUCCESS_URI:http://localhost:3000/perpicks/auth/login/kakao/success}
 


### PR DESCRIPTION
### Summary
* Auth 도메인의 API의 응답 형태를 모두 통일된 구조로 변경하였습니다.
* Swagger 상에서 로그인 API의 최종 리디렉션 url을 명세하였습니다.
* 기존 인가 코드를 발급받는 API를 client쪽으로 지정하는 방향으로 롤백함에 따라 yaml 상의 redirection url을 맞게 수정하였습니다.