### PR TITLE
[PURPLE-000] 스프링 기본 active profile 지정

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -9,6 +9,7 @@ services:
     pull_policy: always
     env_file:
       - .env
+      - SPRING_PROFILES_ACTIVE=dev
     depends_on:
       - mysql
     ports:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,8 +3,6 @@ server:
   shutdown: graceful
 
 spring:
-  profiles:
-    active: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL:jdbc:mysql://localhost:3306/purple?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ server:
   shutdown: graceful
 
 spring:
+  profiles:
+    active: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL:jdbc:mysql://localhost:3306/purple?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}


### PR DESCRIPTION
### Summary
<img width="1451" alt="스크린샷 2024-07-23 오후 11 28 18" src="https://github.com/user-attachments/assets/7e4802c5-cf10-413b-84cc-4311ee2d4a49">
* 개발쪽 로그 확인해 봤을 때 기본 active profile이 지정이 안 되어 있어서 default로 실행되고 있더라구요..! 이게 저희 개발서버 DB쪽 이슈랑 연관되는 것 같아서 체킹차 PR 올립니다.