### PR TITLE
[PURPLE-116] 로그인 토큰 전달 방식 redirection에서 response body로 변경

### DIFF
--- a/src/main/java/com/pikachu/purple/application/common/properties/KakaoSocialLoginProperties.java
+++ b/src/main/java/com/pikachu/purple/application/common/properties/KakaoSocialLoginProperties.java
@@ -14,5 +14,4 @@ public class KakaoSocialLoginProperties {
     private final String tokenRequestUri;
     private final String redirectUri;
     private final String jwksUri;
-    private final String loginSuccessUri;
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
@@ -1,14 +1,10 @@
 package com.pikachu.purple.application.user.port.in;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 
 public interface SocialLoginUseCase {
 
-    Result invoke(SocialLoginUseCase.Command command)
-        throws MalformedURLException, JwkException, URISyntaxException;
+    Result invoke(SocialLoginUseCase.Command command);
 
     record Command(
         SocialLoginProvider socialLoginProvider,
@@ -17,9 +13,6 @@ public interface SocialLoginUseCase {
 
     }
 
-    record Result(
-        String socialLoginSuccessUrl
-    ) {
-
+    record Result(String jwtToken) {
     }
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
@@ -1,6 +1,5 @@
 package com.pikachu.purple.application.user.service.application;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.common.properties.KakaoSocialLoginProperties;
 import com.pikachu.purple.application.user.port.in.SocialLoginUseCase;
 import com.pikachu.purple.application.user.port.in.UserSignUpUseCase;
@@ -10,9 +9,6 @@ import com.pikachu.purple.application.user.service.util.UserTokenService;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.domain.user.entity.User;
 import com.pikachu.purple.domain.user.vo.SocialLoginToken;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,8 +27,7 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
     private final UserSignUpUseCase userSignUpUseCase;
 
     @Override
-    public Result invoke(Command command)
-        throws MalformedURLException, JwkException, URISyntaxException {
+    public Result invoke(Command command) {
         SocialLoginToken socialLoginToken = socialLoginService.getToken(
             command.socialLoginProvider(),
             command.authorizationCode()
@@ -73,19 +68,7 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
             refreshToken
         );
 
-        return new SocialLoginUseCase.Result(
-            generateLoginSuccessUri(jwtToken).toString()
-        );
-    }
-
-    private URI generateLoginSuccessUri(String jwtToken) throws URISyntaxException {
-        String redirectUri = kakaoSocialLoginProperties.getLoginSuccessUri();
-
-        String loginSuccessUri =
-            redirectUri + QUERY_PARAMETER_PREFIX + QUERY_PARAMETER_TOKEN_KEY
-                + QUERY_PARAMETER_DELIMITER + jwtToken;
-
-        return new URI(loginSuccessUri);
+        return new SocialLoginUseCase.Result(jwtToken);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/UserTokenService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/UserTokenService.java
@@ -1,20 +1,18 @@
 package com.pikachu.purple.application.user.service.util;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.user.vo.tokens.AccessToken;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.application.user.vo.tokens.JwtToken;
 import com.pikachu.purple.application.user.vo.tokens.RefreshToken;
 import com.pikachu.purple.domain.user.entity.User;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-import java.net.MalformedURLException;
 
 public interface UserTokenService {
 
     IdToken resolveIdToken(
         String idToken,
         SocialLoginProvider provider
-    ) throws MalformedURLException, JwkException;
+    );
 
     AccessToken resolveAccessToken(String accessToken);
 

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
@@ -2,7 +2,6 @@ package com.pikachu.purple.application.user.service.util.impl;
 
 import static com.pikachu.purple.bootstrap.common.exception.BusinessException.AccessTokenExpiredException;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.common.properties.JwtTokenProperties;
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
 import com.pikachu.purple.application.user.service.util.UserTokenService;
@@ -20,7 +19,6 @@ import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import com.pikachu.purple.support.security.auth.util.JwtTokenProvider;
 import com.pikachu.purple.support.security.auth.vo.JwtClaims;
 import com.pikachu.purple.support.security.auth.vo.JwtClaims.RegisteredClaims;
-import java.net.MalformedURLException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -41,8 +39,7 @@ public class UserTokenServiceImpl implements UserTokenService {
     public IdToken resolveIdToken(
         String idToken,
         SocialLoginProvider provider
-    )
-        throws MalformedURLException, JwkException {
+    ) {
         SocialLoginStrategy socialLoginStrategy = socialLoginStrategyFactory.getStrategy(provider);
 
         return socialLoginStrategy.resolveIdToken(idToken);
@@ -59,9 +56,7 @@ public class UserTokenServiceImpl implements UserTokenService {
         );
         String email = jwtClaims.getCustomClaims().get("email").toString().replace("\"", "");
 
-        userTokenRepository.findAccessTokenByUserId(
-            Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
-        ).orElseThrow(() -> AccessTokenExpiredException);
+        userTokenRepository.findAccessTokenByUserId(userId).orElseThrow(() -> AccessTokenExpiredException);
 
         return new AccessToken(
             userId,

--- a/src/main/java/com/pikachu/purple/application/user/service/util/strategy/KakaoSocialLoginStrategy.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/strategy/KakaoSocialLoginStrategy.java
@@ -1,6 +1,5 @@
 package com.pikachu.purple.application.user.service.util.strategy;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.common.properties.KakaoSocialLoginProperties;
 import com.pikachu.purple.application.user.port.out.SocialLoginPort;
 import com.pikachu.purple.application.user.vo.SocialLoginTokenRequest;
@@ -23,7 +22,6 @@ public class KakaoSocialLoginStrategy implements SocialLoginStrategy {
 
     private static final String QUERY_PARAMETER_PREFIX = "?";
     private static final String ENCODED_QUERY_PARAMETER_DELIMETER = "&";
-
     private static final String GRANT_TYPE = "authorization_code";
 
     private final KakaoSocialLoginProperties kakaoSocialLoginProperties;
@@ -61,13 +59,16 @@ public class KakaoSocialLoginStrategy implements SocialLoginStrategy {
     }
 
     @Override
-    public IdToken resolveIdToken(String idToken) throws MalformedURLException, JwkException {
-        URL jwksUri = new URL(this.kakaoSocialLoginProperties.getJwksUri());
+    public IdToken resolveIdToken(String idToken) {
+        try {
+            URL jwksUri = new URL(this.kakaoSocialLoginProperties.getJwksUri());
 
-        JwtClaims result = jwtTokenProvider.verifyJwksBasedToken(idToken, jwksUri);
+            JwtClaims result = jwtTokenProvider.verifyJwksBasedToken(idToken, jwksUri);
 
-        String email = result.getCustomClaims().get("email").toString();
-
-        return new IdToken(email);
+            String email = result.getCustomClaims().get("email").toString();
+            return new IdToken(email);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("jwksUri 설정이 올바르지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/strategy/SocialLoginStrategy.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/strategy/SocialLoginStrategy.java
@@ -1,9 +1,7 @@
 package com.pikachu.purple.application.user.service.util.strategy;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.domain.user.vo.SocialLoginToken;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -13,6 +11,6 @@ public interface SocialLoginStrategy {
 
     SocialLoginToken getToken(String authorizationCode);
 
-    IdToken resolveIdToken(String idToken) throws MalformedURLException, JwkException;
+    IdToken resolveIdToken(String idToken);
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -1,16 +1,13 @@
 package com.pikachu.purple.bootstrap.auth.api;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
+import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,19 +28,13 @@ public interface AuthApi {
         @PathVariable("provider") SocialLoginProvider provider
     ) throws URISyntaxException;
 
-    @Operation(summary = "소셜 로그인", responses = {
-        @ApiResponse(responseCode = "302", description =
-            "로그인 성공, jwt token query parameter를 담아 FE로 리디렉션되어 전달됩니다. \n\n"
-                + "**최종 redirect url : {client ip}/perpicks/auth/login/kakao/success?token={jwt token}**"
-        )
-    })
+    @Operation(summary = "소셜 로그인")
     @PostMapping("/login/{provider}")
     @ResponseStatus(HttpStatus.OK)
-    void socialLogin(
+    SuccessResponse<SocialLoginResponse> socialLogin(
         @PathVariable("provider") SocialLoginProvider provider,
-        @RequestParam String code,
-        HttpServletResponse response
-    ) throws IOException, JwkException, URISyntaxException;
+        @RequestParam String code
+    );
 
     @Operation(summary = "Jwt Token Refresh API")
     @PostMapping("/refresh")

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -1,17 +1,15 @@
 package com.pikachu.purple.bootstrap.auth.controller;
 
-import com.auth0.jwk.JwkException;
 import com.pikachu.purple.application.user.port.in.RefreshJwtTokenUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginUseCase;
 import com.pikachu.purple.bootstrap.auth.api.AuthApi;
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
+import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,11 +36,10 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public void socialLogin(
+    public SuccessResponse<SocialLoginResponse> socialLogin(
         SocialLoginProvider provider,
-        String code,
-        HttpServletResponse response
-    ) throws IOException, JwkException, URISyntaxException {
+        String code
+    ) {
         SocialLoginUseCase.Result result = socialLoginUseCase.invoke(
             new SocialLoginUseCase.Command(
                 provider,
@@ -50,7 +47,9 @@ public class AuthController implements AuthApi {
             )
         );
 
-        response.sendRedirect(result.socialLoginSuccessUrl());
+        return SuccessResponse.of(
+            new SocialLoginResponse(result.jwtToken())
+        );
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,13 @@
+package com.pikachu.purple.bootstrap.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+    name = "SocialLoginResponse",
+    description = "소셜 로그인 API 응답"
+)
+public record SocialLoginResponse(
+    @Schema(description = "jwt token")
+    String jwtToken
+) {
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/BusinessException.java
@@ -5,59 +5,50 @@ import lombok.Getter;
 @Getter
 public class BusinessException extends RuntimeException {
 
+    public static final BusinessException EmailExistedException = new BusinessException(
+        ErrorCode.EMAIL_ALREADY_EXISTED
+    );
+    public static final BusinessException InvalidEmailException = new BusinessException(
+        ErrorCode.INVALID_EMAIL_FORMAT
+    );
+    public static final BusinessException UserNotFoundException = new BusinessException(
+        ErrorCode.USER_NOT_FOUND
+    );
+    public static final BusinessException NicknameAlreadyExistedException = new BusinessException(
+        ErrorCode.NICKNAME_ALREADY_EXISTED
+    );
+    public static final BusinessException InvalidVerifyCodeException = new BusinessException(
+        ErrorCode.INVALID_VERIFY_CODE
+    );
+    public static final BusinessException AccessTokenExpiredException = new BusinessException(
+        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
+    );
+    public static final BusinessException RefreshTokenExpiredException = new BusinessException(
+        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
+    );
+    public static final BusinessException RefreshTokenNotFoundException = new BusinessException(
+        ErrorCode.REFRESH_TOKEN_NOT_FOUND
+    );
+    public static final BusinessException NotValidLoginIdTokenException = new BusinessException(
+        ErrorCode.NOT_VALID_LOGIN_ID_TOKEN
+    );
+    public static final BusinessException FileEmptyException = new BusinessException(
+        ErrorCode.FILE_EMPTY_EXCEPTION
+    );
+    public static final BusinessException FileUploadFailException = new BusinessException(
+        ErrorCode.FILE_UPLOAD_FAIL_EXCEPTION
+    );
+    public static final BusinessException InvalidFileExtensionException = new BusinessException(
+        ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION
+    );
+    public static final BusinessException FileDeleteFailException = new BusinessException(
+        ErrorCode.FILE_DELETE_FAIL_EXCEPTION
+    );
     private final ErrorCode errorCode;
 
     public BusinessException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
-
-    public static final BusinessException EmailExistedException = new BusinessException(
-        ErrorCode.EMAIL_ALREADY_EXISTED
-    );
-
-    public static final BusinessException InvalidEmailException = new BusinessException(
-        ErrorCode.INVALID_EMAIL_FORMAT
-    );
-
-    public static final BusinessException UserNotFoundException = new BusinessException(
-        ErrorCode.USER_NOT_FOUND
-    );
-
-    public static final BusinessException NicknameAlreadyExistedException = new BusinessException(
-        ErrorCode.NICKNAME_ALREADY_EXISTED
-    );
-
-    public static final BusinessException InvalidVerifyCodeException = new BusinessException(
-        ErrorCode.INVALID_VERIFY_CODE
-    );
-
-    public static final BusinessException AccessTokenExpiredException = new BusinessException(
-        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
-    );
-
-    public static final BusinessException RefreshTokenExpiredException = new BusinessException(
-        ErrorCode.ACCESS_TOKEN_EXPIRED_EXCEPTION
-    );
-
-    public static final BusinessException RefreshTokenNotFoundException = new BusinessException(
-        ErrorCode.REFRESH_TOKEN_NOT_FOUND
-    );
-
-    public static final BusinessException FileEmptyException = new BusinessException(
-        ErrorCode.FILE_EMPTY_EXCEPTION
-    );
-
-    public static final BusinessException FileUploadFailException = new BusinessException(
-        ErrorCode.FILE_UPLOAD_FAIL_EXCEPTION
-    );
-
-    public static final BusinessException InvalidFileExtensionException = new BusinessException(
-        ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION
-    );
-
-    public static final BusinessException FileDeleteFailException = new BusinessException(
-        ErrorCode.FILE_DELETE_FAIL_EXCEPTION
-    );
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -82,6 +82,12 @@ public enum ErrorCode {
         "리프레시 토큰을 찾을 수 없습니다."
     ),
 
+    NOT_VALID_LOGIN_ID_TOKEN(
+        400,
+        "J006",
+        "유효하지 않은 ID Token입니다. 토큰을 새롭게 발급받아 사용하세요."
+    ),
+
     // S3
     FILE_EMPTY_EXCEPTION(
         400,

--- a/src/main/java/com/pikachu/purple/infrastructure/client/auth/kakao/adapter/KakaoSocialLoginAdapter.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/client/auth/kakao/adapter/KakaoSocialLoginAdapter.java
@@ -2,6 +2,8 @@ package com.pikachu.purple.infrastructure.client.auth.kakao.adapter;
 
 import com.pikachu.purple.application.user.port.out.SocialLoginPort;
 import com.pikachu.purple.application.user.vo.SocialLoginTokenRequest;
+import com.pikachu.purple.bootstrap.common.exception.BusinessException;
+import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
 import com.pikachu.purple.domain.user.vo.SocialLoginToken;
 import com.pikachu.purple.infrastructure.client.auth.kakao.util.KakaoSocialLoginClient;
 import lombok.RequiredArgsConstructor;
@@ -15,12 +17,17 @@ public class KakaoSocialLoginAdapter implements SocialLoginPort {
 
     @Override
     public SocialLoginToken getToken(SocialLoginTokenRequest socialLoginTokenRequest) {
-        return kakaoSocialLoginClient.getToken(
-            socialLoginTokenRequest.grantType(),
-            socialLoginTokenRequest.clientId(),
-            socialLoginTokenRequest.redirectUri(),
-            socialLoginTokenRequest.authorizationCode()
-        );
+        try {
+            return kakaoSocialLoginClient.getToken(
+                socialLoginTokenRequest.grantType(),
+                socialLoginTokenRequest.clientId(),
+                socialLoginTokenRequest.redirectUri(),
+                socialLoginTokenRequest.authorizationCode()
+            );
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.NOT_VALID_LOGIN_ID_TOKEN);
+        }
+
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,10 +57,8 @@ auth:
     client-id: ${KAKAO_CLIENT_ID}
     response-type: code
     authorize-uri: https://kauth.kakao.com/oauth/authorize
-    #    token-request-uri: https://kauth.kakao.com/oauth/token
     redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/perpicks/auth/login/kakao}
     jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
-    login-success-uri: ${KAKAO_LOGIN_SUCCESS_URI:http://localhost:3000/perpicks/auth/login/kakao/success}
 
 uri:
   server: ${SERVER_URI:http://localhost:8080}


### PR DESCRIPTION
### Summary
* FE 요청에 따라 로그인 토큰 전달 방식을 redirection에서 response body로 전달되도록 변경합니다.
* 토큰 검증 로직 내 try-catch문 도입을 통해 커스텀 에러로 핸들링되도록 변경하였습니다.

### 제안 사항
* 커스텀 에러에 대한 리팩토링을 한번 해야할 것 같네요..! 생각보다 핸들링처리하지 않은 에러들도 보여서 API 연결 시에 어려움이 있을수도 있을 것 같네요! 조금 더 꼼꼼하게 엣지 케이스 처리를 해 두어야 할 것 같습니다~