### PR TITLE
[PURPLE-120] PerfumeBrandName entity 수정 및 온보딩 시 인생향수 생성

### DIFF
--- a/src/main/java/com/pikachu/purple/PurpleApplication.java
+++ b/src/main/java/com/pikachu/purple/PurpleApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @OpenAPIDefinition(
     servers = {
@@ -18,6 +19,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @EnableConfigurationProperties({KakaoSocialLoginProperties.class, JwtTokenProperties.class})
 @EnableFeignClients
+@EnableJpaAuditing
 public class PurpleApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/pikachu/purple/application/favorite/port/in/FavoriteCreateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/port/in/FavoriteCreateUseCase.java
@@ -1,0 +1,9 @@
+package com.pikachu.purple.application.favorite.port.in;
+
+import java.util.List;
+
+public interface FavoriteCreateUseCase {
+
+    void invoke(List<Long> perfumeIds);
+
+}

--- a/src/main/java/com/pikachu/purple/application/favorite/port/out/FavoriteRepository.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/port/out/FavoriteRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.favorite.port.out;
+
+import com.pikachu.purple.domain.favorite.Favorite;
+import java.util.List;
+
+public interface FavoriteRepository {
+
+    void create(List<Favorite> favorites);
+
+}

--- a/src/main/java/com/pikachu/purple/application/favorite/service/application/FavoriteCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/service/application/FavoriteCreateApplicationService.java
@@ -1,0 +1,38 @@
+package com.pikachu.purple.application.favorite.service.application;
+
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
+import com.pikachu.purple.application.favorite.port.in.FavoriteCreateUseCase;
+import com.pikachu.purple.application.favorite.service.domain.FavoriteDomainService;
+import com.pikachu.purple.application.util.IdGenerator;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteCreateApplicationService implements FavoriteCreateUseCase {
+
+    private final FavoriteDomainService favoriteDomainService;
+
+    @Transactional
+    @Override
+    public void invoke(List<Long> perfumeIds) {
+        Long userId = getCurrentUserAuthentication().userId();
+
+        List<Long> favoriteIds = IntStream.range(0, perfumeIds.size())
+            .mapToObj(i -> IdGenerator.generate())
+            .toList();
+
+        favoriteDomainService.create(
+            favoriteIds,
+            userId,
+            perfumeIds
+        );
+
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/favorite/service/domain/FavoriteDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/service/domain/FavoriteDomainService.java
@@ -1,0 +1,13 @@
+package com.pikachu.purple.application.favorite.service.domain;
+
+import java.util.List;
+
+public interface FavoriteDomainService {
+
+    void create(
+        List<Long> favoriteIds,
+        Long userId,
+        List<Long> perfumeIds
+    );
+
+}

--- a/src/main/java/com/pikachu/purple/application/favorite/service/domain/impl/FavoriteDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/service/domain/impl/FavoriteDomainServiceImpl.java
@@ -1,0 +1,36 @@
+package com.pikachu.purple.application.favorite.service.domain.impl;
+
+import com.pikachu.purple.application.favorite.port.out.FavoriteRepository;
+import com.pikachu.purple.application.favorite.service.domain.FavoriteDomainService;
+import com.pikachu.purple.domain.favorite.Favorite;
+import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteDomainServiceImpl implements FavoriteDomainService {
+
+    private final FavoriteRepository favoriteRepository;
+
+    @Override
+    public void create(
+        List<Long> favoriteIds,
+        Long userId,
+        List<Long> perfumeIds
+    ) {
+        List<Favorite> favorites = IntStream.range(0, favoriteIds.size())
+            .mapToObj(i -> Favorite.builder()
+                .favoriteId(favoriteIds.get(i))
+                .userId(userId)
+                .perfumeId(perfumeIds.get(i))
+                .entityStatus(EntityStatus.ACTIVE)
+                .build())
+            .toList();
+
+        favoriteRepository.create(favorites);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeBrandRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeBrandRepository.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface PerfumeBrandRepository {
 
-    List<PerfumeBrand> findTopThirtyBrands();
+    List<PerfumeBrand> getTopThirty();
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeBrandGetTopThirtyApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/PerfumeBrandGetTopThirtyApplicationService.java
@@ -16,7 +16,7 @@ public class PerfumeBrandGetTopThirtyApplicationService implements
 
     @Override
     public PerfumeBrandGetTopThirtyUseCase.Result invoke() {
-        List<PerfumeBrand> perfumeBrands = perfumeBrandDomainService.findTopThirtyBrands();
+        List<PerfumeBrand> perfumeBrands = perfumeBrandDomainService.getTopThirty();
 
         return new PerfumeBrandGetTopThirtyUseCase.Result(perfumeBrands);
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeBrandDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeBrandDomainService.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface PerfumeBrandDomainService {
 
-    List<PerfumeBrand> findTopThirtyBrands();
+    List<PerfumeBrand> getTopThirty();
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeBrandDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeBrandDomainServiceImpl.java
@@ -15,8 +15,8 @@ public class PerfumeBrandDomainServiceImpl implements PerfumeBrandDomainService 
     private final PerfumeBrandRepository perfumeBrandRepository;
 
     @Override
-    public List<PerfumeBrand> findTopThirtyBrands() {
-        return perfumeBrandRepository.findTopThirtyBrands();
+    public List<PerfumeBrand> getTopThirty() {
+        return perfumeBrandRepository.getTopThirty();
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingSaveApplicationService.java
@@ -2,10 +2,12 @@ package com.pikachu.purple.application.rating.service.application;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
+import com.pikachu.purple.application.favorite.port.in.FavoriteCreateUseCase;
 import com.pikachu.purple.application.rating.port.in.RatingSaveUseCase;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
 import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteSaveUseCase;
 import com.pikachu.purple.application.util.IdGenerator;
+import com.pikachu.purple.bootstrap.user.vo.RatingValue;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +21,7 @@ public class RatingSaveApplicationService implements RatingSaveUseCase {
 
     private final RatingDomainService ratingDomainService;
     private final UserPreferenceNoteSaveUseCase userPreferenceNoteSaveUseCase;
+    private final FavoriteCreateUseCase favoriteCreateUseCase;
 
     @Transactional
     @Override
@@ -36,6 +39,11 @@ public class RatingSaveApplicationService implements RatingSaveUseCase {
         );
 
         userPreferenceNoteSaveUseCase.invoke();
+
+        List<Long> perfumeIds = command.ratingValues().stream()
+            .map(RatingValue::perfumeId)
+            .toList();
+        favoriteCreateUseCase.invoke(perfumeIds);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
+++ b/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
@@ -1,0 +1,30 @@
+package com.pikachu.purple.domain.favorite;
+
+import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Favorite {
+
+    private Long favoriteId;
+    private Long userId;
+    private Long perfumeId;
+    private EntityStatus entityStatus;
+
+    @Builder
+    public Favorite(
+        Long favoriteId,
+        Long userId,
+        Long perfumeId,
+        EntityStatus entityStatus
+    ) {
+        this.favoriteId = favoriteId;
+        this.userId = userId;
+        this.perfumeId = perfumeId;
+        this.entityStatus = entityStatus;
+    }
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/adaptor/FavoriteJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/adaptor/FavoriteJpaAdaptor.java
@@ -1,0 +1,26 @@
+package com.pikachu.purple.infrastructure.persistence.favorite.adaptor;
+
+import com.pikachu.purple.application.favorite.port.out.FavoriteRepository;
+import com.pikachu.purple.domain.favorite.Favorite;
+import com.pikachu.purple.infrastructure.persistence.favorite.entity.FavoriteJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.favorite.repository.FavoriteJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FavoriteJpaAdaptor implements FavoriteRepository {
+
+    private final FavoriteJpaRepository favoriteJpaRepository;
+
+    @Override
+    public void create(List<Favorite> favorites) {
+        List<FavoriteJpaEntity> favoriteJpaEntities = favorites.stream()
+            .map(FavoriteJpaEntity::toJpaEntity)
+            .toList();
+
+        favoriteJpaRepository.saveAll(favoriteJpaEntities);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.infrastructure.persistence.favorite.entity;
 
+import com.pikachu.purple.domain.favorite.Favorite;
 import com.pikachu.purple.infrastructure.persistence.common.BaseEntity;
 import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import jakarta.persistence.Column;
@@ -9,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,5 +33,27 @@ public class FavoriteJpaEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "entity_status")
     private EntityStatus entityStatus;
+
+    @Builder
+    public FavoriteJpaEntity(
+        Long favoriteId,
+        Long userId,
+        Long perfumeId,
+        EntityStatus entityStatus
+    ) {
+        this.favoriteId = favoriteId;
+        this.userId = userId;
+        this.perfumeId = perfumeId;
+        this.entityStatus = entityStatus;
+    }
+
+    public static FavoriteJpaEntity toJpaEntity(Favorite favorite) {
+        return FavoriteJpaEntity.builder()
+            .favoriteId(favorite.getFavoriteId())
+            .userId(favorite.getUserId())
+            .perfumeId(favorite.getPerfumeId())
+            .entityStatus(favorite.getEntityStatus())
+            .build();
+    }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/repository/FavoriteJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/repository/FavoriteJpaRepository.java
@@ -1,0 +1,8 @@
+package com.pikachu.purple.infrastructure.persistence.favorite.repository;
+
+import com.pikachu.purple.infrastructure.persistence.favorite.entity.FavoriteJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteJpaRepository extends JpaRepository<FavoriteJpaEntity, Long> {
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeBrandJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeBrandJpaAdaptor.java
@@ -7,9 +7,6 @@ import com.pikachu.purple.infrastructure.persistence.perfume.repository.PerfumeB
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,9 +17,8 @@ public class PerfumeBrandJpaAdaptor implements PerfumeBrandRepository {
     private final PerfumeBrandJpaRepository perfumeBrandJpaRepository;
 
     @Override
-    public List<PerfumeBrand> findTopThirtyBrands() {
-        Pageable pageable = PageRequest.of(0, MAX_SIZE);
-        Page<PerfumeBrandJpaEntity> perfumeBrandEntityList = perfumeBrandJpaRepository.findAll(pageable);
+    public List<PerfumeBrand> getTopThirty() {
+        List<PerfumeBrandJpaEntity> perfumeBrandEntityList = perfumeBrandJpaRepository.getTopThirtyBy(MAX_SIZE);
         return perfumeBrandEntityList.stream()
             .map(PerfumeBrandJpaEntity::toDomain)
             .collect(Collectors.toList());

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeBrandJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeBrandJpaRepository.java
@@ -1,10 +1,15 @@
 package com.pikachu.purple.infrastructure.persistence.perfume.repository;
 
 import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeBrandJpaEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PerfumeBrandJpaRepository extends JpaRepository<PerfumeBrandJpaEntity, String> {
+
+    @Query(value = "SELECT * FROM perfume_brand ORDER BY display_order LIMIT :maxSize", nativeQuery = true)
+    List<PerfumeBrandJpaEntity> getTopThirtyBy(int maxSize);
 
 }


### PR DESCRIPTION
### 진행상황
- PerfumeBrandName Entity 조회 시 정해진 조회 순서대로 정렬하기 위해, Secondary index를 적용했습니다.
- 온보딩 향수 선택 시 인생향수 값도 생성하는 로직으로 변경했습니다.
- BaseEntity를 이용하여, 컬럼이 생성 혹은 업데이트 될 때 Jpa Auditing을 사용하여 자동 업데이트 하게 하였습니다.

### 추후 PR 예정
- 온보딩 향수 선택 및 평가 시 간단한 리뷰 추가 및 로직 변경
- 간단한 리뷰 CUD