### PR TITLE
[PURPLE-122] Refresh Token API 에러 해결

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
@@ -1,11 +1,11 @@
 package com.pikachu.purple.application.user.service.application;
 
+import static com.pikachu.purple.bootstrap.common.exception.BusinessException.RefreshTokenNotFoundException;
+
 import com.pikachu.purple.application.user.port.in.RefreshJwtTokenUseCase;
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
 import com.pikachu.purple.application.user.service.domain.UserDomainService;
 import com.pikachu.purple.application.user.service.util.UserTokenService;
-import com.pikachu.purple.bootstrap.common.exception.BusinessException;
-import com.pikachu.purple.bootstrap.common.exception.ErrorCode;
 import com.pikachu.purple.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +26,7 @@ public class RefreshJwtTokenApplicationService implements RefreshJwtTokenUseCase
         Long userId = userTokenService.resolveRefreshToken(refreshToken).getUserId();
 
         userTokenRepository.findRefreshTokenByUserId(userId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+            .orElseThrow(() -> RefreshTokenNotFoundException);
 
         User user = userDomainService.getById(userId);
         String accessToken = userTokenService.generateAccessToken(user);

--- a/src/main/java/com/pikachu/purple/application/user/service/util/SocialLoginService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/SocialLoginService.java
@@ -14,5 +14,4 @@ public interface SocialLoginService {
         String authorizationCode
     );
 
-
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
@@ -71,13 +71,13 @@ public class UserTokenServiceImpl implements UserTokenService {
             jwtTokenProperties.getRefresh().secret()
         );
 
-        userTokenRepository.findRefreshTokenByUserId(
-            Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
-        ).orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+        Long userId = Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString()
+            .substring(1, jwtClaims.getCustomClaims().get("userId").toString().length() - 1));
 
-        return new RefreshToken(
-            Long.valueOf(jwtClaims.getCustomClaims().get("userId").toString())
-        );
+        userTokenRepository.findRefreshTokenByUserId(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        return new RefreshToken(userId);
     }
 
     @Override
@@ -87,9 +87,14 @@ public class UserTokenServiceImpl implements UserTokenService {
             jwtTokenProperties.getJwt().secret()
         );
 
+        String accessToken = jwtClaims.getCustomClaims().get("accessToken").toString();
+        accessToken = accessToken.substring(1, accessToken.length() - 1);
+        String refreshToken = jwtClaims.getCustomClaims().get("refreshToken").toString();
+        refreshToken = refreshToken.substring(1, refreshToken.length() - 1);
+
         return new JwtToken(
-            jwtClaims.getCustomClaims().get("accessToken").toString(),
-            jwtClaims.getCustomClaims().get("refreshToken").toString()
+            accessToken,
+            refreshToken
         );
     }
 

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/GlobalExceptionHandler.java
@@ -25,17 +25,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return makeErrorResponse(errorCode);
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleException(Exception e) {
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<?> handleException(Throwable e) {
         log.error("handleException", e);
         return makeErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     private ResponseEntity<?> makeErrorResponse(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getStatus())
-            .body(ErrorResponse.of(
-                errorCode.getCode(),
-                errorCode.getMessage())
+            .body(
+                ErrorResponse.of(
+                    errorCode.getCode(),
+                    errorCode.getMessage()
+                )
             );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,7 +6,6 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL:jdbc:mysql://localhost:3306/purple?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:secret}
   jpa:
@@ -40,7 +39,6 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
-
 
 auth:
   jwt:


### PR DESCRIPTION
### Summary
* Refresh Token API 에러를 해결하였습니다.

* 토큰을 toString()으로 반환하는 과정에서 `""` 해당 기호가 양옆에 추가되어 토큰 생성 시 invalid한 값이 입력되는 문제입니다.
* 에러를 throw하는 과정에서 BusinessException 내에 정의된 static method를 사용하지 않아 ExceptionHandler를 거치지 못하고 500으로 떨어지는 현상을 해결했습니다.