### PR TITLE
[PURPLE-124] 향수 상세정보 관련 엔티티 및 도메인 추가

### DIFF
--- a/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
@@ -1,0 +1,38 @@
+package com.pikachu.purple.domain.evaluation;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FragranticaEvaluation {
+
+    private Long fragranticaEvaluationId;
+    private Long perfumeId;
+    private String fieldCode;
+    private String fieldName;
+    private String optionCode;
+    private String optionName;
+    private Integer votes;
+
+    @Builder
+    public FragranticaEvaluation(
+            Long fragranticaEvaluationId,
+            Long perfumeId,
+            String fieldCode,
+            String fieldName,
+            String optionCode,
+            String optionName,
+            Integer votes
+    ) {
+        this.fragranticaEvaluationId = fragranticaEvaluationId;
+        this.perfumeId = perfumeId;
+        this.fieldCode = fieldCode;
+        this.fieldName = fieldName;
+        this.optionCode = optionCode;
+        this.optionName = optionName;
+        this.votes = votes;
+    }
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
@@ -15,7 +15,7 @@ public class FragranticaEvaluation {
     private String fieldName;
     private String optionCode;
     private String optionName;
-    private Integer votes;
+    private int votes;
 
     @Builder
     public FragranticaEvaluation(

--- a/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
@@ -35,4 +35,5 @@ public class FragranticaEvaluation {
         this.optionName = optionName;
         this.votes = votes;
     }
+
 }

--- a/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationCodeType.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationCodeType.java
@@ -1,0 +1,5 @@
+package com.pikachu.purple.domain.evaluation.enums;
+
+public enum EvaluationCodeType {
+    FIELD, OPTION
+}

--- a/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
+++ b/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
@@ -12,7 +12,7 @@ public class MainAccord {
     private Long mainAccordId;
     private Long perfumeId;
     private String noteName;
-    private Integer accordValue;
+    private int accordValue;
 
     @Builder
     public MainAccord(

--- a/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
+++ b/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
@@ -1,0 +1,29 @@
+package com.pikachu.purple.domain.mainAccord;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MainAccord {
+
+    private Long mainAccordId;
+    private Long perfumeId;
+    private String noteName;
+    private Integer accordValue;
+
+    @Builder
+    public MainAccord(
+            Long mainAccordId,
+            Long perfumeId,
+            String noteName,
+            Integer accordValue
+    ) {
+        this.mainAccordId = mainAccordId;
+        this.perfumeId = perfumeId;
+        this.noteName = noteName;
+        this.accordValue = accordValue;
+    }
+}

--- a/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
+++ b/src/main/java/com/pikachu/purple/domain/mainAccord/MainAccord.java
@@ -26,4 +26,5 @@ public class MainAccord {
         this.noteName = noteName;
         this.accordValue = accordValue;
     }
+
 }

--- a/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
+++ b/src/main/java/com/pikachu/purple/domain/perfume/PerfumeNote.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.domain.perfume;
 
+import com.pikachu.purple.domain.perfume.enums.PerfumeNoteType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,16 +13,19 @@ public class PerfumeNote {
     private Long perfumeNoteId;
     private Long perfumeId;
     private String noteName;
+    private PerfumeNoteType perfumeNoteType;
 
     @Builder
     public PerfumeNote(
         Long perfumeNoteId,
         Long perfumeId,
-        String noteName
+        String noteName,
+        PerfumeNoteType perfumeNoteType
     ) {
         this.perfumeNoteId = perfumeNoteId;
         this.perfumeId = perfumeId;
         this.noteName = noteName;
+        this.perfumeNoteType = perfumeNoteType;
     }
 
 }

--- a/src/main/java/com/pikachu/purple/domain/perfume/enums/PerfumeNoteType.java
+++ b/src/main/java/com/pikachu/purple/domain/perfume/enums/PerfumeNoteType.java
@@ -1,0 +1,5 @@
+package com.pikachu.purple.domain.perfume.enums;
+
+public enum PerfumeNoteType {
+    TOP, MIDDLE, BASE
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "evaluation_code")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EvaluationCodeJpaEntity {
+
     @Id
     @Column(name = "code", columnDefinition = "char(5)", nullable = false)
     private String code;
@@ -21,4 +22,5 @@ public class EvaluationCodeJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "type", columnDefinition = "varchar(255)", nullable = false)
     private EvaluationCodeType type;
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
@@ -1,0 +1,24 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
+
+import com.pikachu.purple.domain.evaluation.enums.EvaluationCodeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "evaluation_code")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationCodeJpaEntity {
+    @Id
+    @Column(name = "code", columnDefinition = "char(5)", nullable = false)
+    private String code;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", columnDefinition = "varchar(255)", nullable = false)
+    private EvaluationCodeType type;
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
@@ -1,0 +1,31 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "fragrantica_evaluation")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FragranticaEvaluationJpaEntity {
+    @Id
+    @Column(name = "fragrantica_evaluation_id")
+    private Long fragranticaEvaluationId;
+
+    @Column(name = "perfume_id", nullable = false)
+    private Long perfumeId;
+
+    @Column(name = "field_code", columnDefinition = "char(5)", nullable = false)
+    private String fieldCode;
+
+    @Column(name = "option_code", columnDefinition = "char(5)", nullable = false)
+    private String optionCode;
+
+    @Column(name = "votes", nullable = false)
+    private Integer votes;
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "fragrantica_evaluation")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FragranticaEvaluationJpaEntity {
+
     @Id
     @Column(name = "fragrantica_evaluation_id")
     private Long fragranticaEvaluationId;
@@ -28,4 +29,5 @@ public class FragranticaEvaluationJpaEntity {
 
     @Column(name = "votes", nullable = false)
     private int votes;
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
@@ -27,5 +27,5 @@ public class FragranticaEvaluationJpaEntity {
     private String optionCode;
 
     @Column(name = "votes", nullable = false)
-    private Integer votes;
+    private int votes;
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
@@ -25,7 +25,7 @@ public class MainAccordJpaEntity {
     private String noteName;
 
     @Column(name = "accord_value", nullable = false)
-    private Integer accordValue;
+    private int accordValue;
 
     public static MainAccord toDomain(MainAccordJpaEntity mainAccordJpaEntity) {
         return MainAccord.builder()

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "main_accord")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MainAccordJpaEntity {
+
     @Id
     @Column(name = "main_accord_id")
     private Long mainAccordId;
@@ -35,4 +36,5 @@ public class MainAccordJpaEntity {
                 .accordValue(mainAccordJpaEntity.getAccordValue())
                 .build();
     }
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.infrastructure.persistence.mainAccord.entity;
 
+import com.pikachu.purple.domain.mainAccord.MainAccord;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -25,4 +26,13 @@ public class MainAccordJpaEntity {
 
     @Column(name = "accord_value", nullable = false)
     private Integer accordValue;
+
+    public static MainAccord toDomain(MainAccordJpaEntity mainAccordJpaEntity) {
+        return MainAccord.builder()
+                .mainAccordId(mainAccordJpaEntity.getMainAccordId())
+                .perfumeId(mainAccordJpaEntity.getPerfumeId())
+                .noteName(mainAccordJpaEntity.getNoteName())
+                .accordValue(mainAccordJpaEntity.getAccordValue())
+                .build();
+    }
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/mainAccord/entity/MainAccordJpaEntity.java
@@ -1,0 +1,28 @@
+package com.pikachu.purple.infrastructure.persistence.mainAccord.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "main_accord")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MainAccordJpaEntity {
+    @Id
+    @Column(name = "main_accord_id")
+    private Long mainAccordId;
+
+    @Column(name = "perfume_id", nullable = false)
+    private Long perfumeId;
+
+    @Column(name = "note_name", nullable = false)
+    private String noteName;
+
+    @Column(name = "accord_value", nullable = false)
+    private Integer accordValue;
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
@@ -2,13 +2,8 @@ package com.pikachu.purple.infrastructure.persistence.perfume.entity;
 
 import com.pikachu.purple.domain.perfume.PerfumeNote;
 import com.pikachu.purple.domain.perfume.enums.PerfumeNoteType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
 @Entity
@@ -26,7 +21,8 @@ public class PerfumeNoteJpaEntity {
     @Column(name = "note_name")
     private String noteName;
 
-    @Column(name = "perfume_note_type")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "perfume_note_type", columnDefinition = "varchar(255)")
     private PerfumeNoteType perfumeNoteType;
 
     public static PerfumeNote toDomain(PerfumeNoteJpaEntity perfumeNoteJpaEntity) {

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/entity/PerfumeNoteJpaEntity.java
@@ -1,6 +1,7 @@
 package com.pikachu.purple.infrastructure.persistence.perfume.entity;
 
 import com.pikachu.purple.domain.perfume.PerfumeNote;
+import com.pikachu.purple.domain.perfume.enums.PerfumeNoteType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -25,12 +26,16 @@ public class PerfumeNoteJpaEntity {
     @Column(name = "note_name")
     private String noteName;
 
+    @Column(name = "perfume_note_type")
+    private PerfumeNoteType perfumeNoteType;
+
     public static PerfumeNote toDomain(PerfumeNoteJpaEntity perfumeNoteJpaEntity) {
         return PerfumeNote.builder()
-            .perfumeNoteId(perfumeNoteJpaEntity.getPerfumeNoteId())
-            .perfumeId(perfumeNoteJpaEntity.getPerfumeId())
-            .noteName(perfumeNoteJpaEntity.getNoteName())
-            .build();
+                .perfumeNoteId(perfumeNoteJpaEntity.getPerfumeNoteId())
+                .perfumeId(perfumeNoteJpaEntity.getPerfumeId())
+                .noteName(perfumeNoteJpaEntity.getNoteName())
+                .perfumeNoteType(perfumeNoteJpaEntity.getPerfumeNoteType())
+                .build();
     }
 
 }


### PR DESCRIPTION
### Summary
* 메인어코드(MainAccord), 프라그란티카 평가(FragranticaEvaluation), 평가코드정보(EvaluationCode) 관련 엔티티 및 도메인 추가
* PerfumeNote에 perfumeNoteType(발향 순서, TOP/MIDDLE/BASE) 속성 및 enum 추가
* EvaluationCode와 연관되어 있는 상세 코멘트 쪽 UserEvaluation 엔티티 및 도메인은 다른 PR로 올릴 예정

### 현재 ERD 현황입니다, 참고바랍니다.(fk는 임의로 그려넣었습니다.)
![ERD_20240822](https://github.com/user-attachments/assets/c21a375f-9edc-4450-996c-78404660c1c5)

### 계획된 향후 ERD 
- perfume, evaluation, review, rating 등 전체적으로 이상한 부분이 있는 지 봐주시면 감사하겠습니다.
![ERD_20240822_초안](https://github.com/user-attachments/assets/bebe2495-1ccd-447d-b499-ccc7e141290a)

