### PR TITLE
[PURPLE-127] S3 이미지 조회시 다운로드 되는 현상 방지

### DIFF
--- a/src/main/java/com/pikachu/purple/infrastructure/s3/adapter/ImageUrlS3Adaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/s3/adapter/ImageUrlS3Adaptor.java
@@ -36,6 +36,7 @@ public class ImageUrlS3Adaptor implements ImageUrlS3Uploader {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
+                .contentType(file.getContentType())
                 .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));


### PR DESCRIPTION
### 진행상황
- 사용자 프로필 수정 API에서 S3로 이미지 등록 후, 이미지 url로 조회하면 다운로드 되는 현상을 방지하였습니다.