### PR TITLE
[PURPLE-125] soft delete 적용 및 테이블 재설계에 따른 온보딩 로직 변경

### DIFF
--- a/src/main/java/com/pikachu/purple/application/favorite/service/domain/impl/FavoriteDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/favorite/service/domain/impl/FavoriteDomainServiceImpl.java
@@ -3,7 +3,6 @@ package com.pikachu.purple.application.favorite.service.domain.impl;
 import com.pikachu.purple.application.favorite.port.out.FavoriteRepository;
 import com.pikachu.purple.application.favorite.service.domain.FavoriteDomainService;
 import com.pikachu.purple.domain.favorite.Favorite;
-import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,6 @@ public class FavoriteDomainServiceImpl implements FavoriteDomainService {
                 .favoriteId(favoriteIds.get(i))
                 .userId(userId)
                 .perfumeId(perfumeIds.get(i))
-                .entityStatus(EntityStatus.ACTIVE)
                 .build())
             .toList();
 

--- a/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
@@ -11,14 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class RecommendNotesProvider {
 
-    private static final Map<Integer, Double> weightMap = Map.of(
-        5, 1.0,
-        4, 0.8,
-        3, 0.0,
-        2, -0.7,
-        1, -0.9
-    );
-
+    private static final double[] weights = {-0.9, -0.7, 0.0, 0.8, 1.0};
     private static final Map<String, Double> noteScoreMap = new HashMap<>();
 
     public List<Note> getTopThreeNotes(
@@ -51,8 +44,7 @@ public class RecommendNotesProvider {
     }
 
     private double convert(int score){
-        double weight = weightMap.get(score);
-        return score * weight;
+        return score * weights[score-1];
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/util/RecommendNotesProvider.java
@@ -1,11 +1,8 @@
 package com.pikachu.purple.application.perfume.util;
 
-import static com.pikachu.purple.bootstrap.common.exception.BusinessException.ReviewNotFoundException;
-
 import com.pikachu.purple.domain.note.Note;
 import com.pikachu.purple.domain.perfume.PerfumeNote;
 import com.pikachu.purple.domain.rating.Rating;
-import com.pikachu.purple.domain.review.Review;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,31 +11,25 @@ import org.springframework.stereotype.Component;
 @Component
 public class RecommendNotesProvider {
 
-    private static final Map<Double, Double> weightMap = Map.of(
-        5.0, 1.0,
-        4.5, 0.9,
-        4.0, 0.8,
-        3.5, 0.7,
-        3.0, 0.0,
-        2.5, 0.0,
-        2.0, -0.7,
-        1.5, -0.8,
-        1.0, -0.9,
-        0.5, -1.0
+    private static final Map<Integer, Double> weightMap = Map.of(
+        5, 1.0,
+        4, 0.8,
+        3, 0.0,
+        2, -0.7,
+        1, -0.9
     );
 
     private static final Map<String, Double> noteScoreMap = new HashMap<>();
 
     public List<Note> getTopThreeNotes(
-        List<Review> reviews,
         List<Rating> ratings,
         List<PerfumeNote> perfumeNotes
     ) {
         noteScoreMap.clear();
 
         for (Rating rating : ratings) {
-            Long perfumeId = findPerfumeId(reviews, rating);
-            Double score = rating.getScore();
+            Long perfumeId = rating.getPerfumeId();
+            int score = rating.getScore();
             Double weightedScore = convert(score);
 
             for (PerfumeNote note : perfumeNotes) {
@@ -59,15 +50,7 @@ public class RecommendNotesProvider {
             .toList();
     }
 
-    private Long findPerfumeId(List<Review> reviews, Rating rating) {
-        return reviews.stream()
-            .filter(review -> review.getReviewId().equals(rating.getReviewId()))
-            .map(Review::getPerfumeId)
-            .findFirst()
-            .orElseThrow(() -> ReviewNotFoundException);
-    }
-
-    private double convert(double score){
+    private double convert(int score){
         double weight = weightMap.get(score);
         return score * weight;
     }

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.rating.port.in;
 
-import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingInfo;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
@@ -10,7 +10,7 @@ public interface RatingCreateUseCase {
     Rating create(Command command);
 
     record OnboardingCommand(
-        List<RatingValue> ratingValues
+        List<RatingInfo> ratingInfos
     ) {
 
     }

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
@@ -1,23 +1,22 @@
 package com.pikachu.purple.application.rating.port.in;
 
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
 import java.util.List;
 
 public interface RatingCreateUseCase {
 
     void createOnboarding(OnboardingCommand command);
-    void create(Command command);
+    Long create(Command command);
 
     record OnboardingCommand(
-        List<Long> reviewIds,
         List<RatingValue> ratingValues
     ) {
 
     }
 
     record Command(
-        Long reviewId,
-        Double score
+        Long perfumeId,
+        int score
     ) {
 
     }

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingCreateUseCase.java
@@ -1,12 +1,13 @@
 package com.pikachu.purple.application.rating.port.in;
 
 import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
 public interface RatingCreateUseCase {
 
     void createOnboarding(OnboardingCommand command);
-    Long create(Command command);
+    Rating create(Command command);
 
     record OnboardingCommand(
         List<RatingValue> ratingValues

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingDeleteUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingDeleteUseCase.java
@@ -1,0 +1,7 @@
+package com.pikachu.purple.application.rating.port.in;
+
+public interface RatingDeleteUseCase {
+
+    void invoke(Long ratingId);
+
+}

--- a/src/main/java/com/pikachu/purple/application/rating/port/in/RatingUpdateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/in/RatingUpdateUseCase.java
@@ -5,8 +5,8 @@ public interface RatingUpdateUseCase {
     void invoke(Command command);
 
     record Command(
-        Long reviewId,
-        Double score
+        Long ratingId,
+        int score
     ) {
 
     }

--- a/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
@@ -7,7 +7,7 @@ public interface RatingRepository {
 
     void createOnboarding(List<Rating> ratings);
 
-    Long create(Rating rating);
+    Rating create(Rating rating);
 
     List<Rating> getAllByUserId(Long userId);
 

--- a/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/rating/port/out/RatingRepository.java
@@ -7,15 +7,19 @@ public interface RatingRepository {
 
     void createOnboarding(List<Rating> ratings);
 
-    void create(Rating rating);
+    Long create(Rating rating);
 
     List<Rating> getAllByUserId(Long userId);
 
-    Rating getByUserIdAndReviewId(
-        Long userId,
-        Long reviewId
-    );
+    Rating getById(Long ratingId);
 
     void save(Rating rating);
+
+    Rating getByIdAndUserId(
+        Long ratingId,
+        Long userId
+    );
+
+    void delete(Rating rating);
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingCreateApplicationService.java
@@ -8,6 +8,7 @@ import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
 import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteCreateUseCase;
 import com.pikachu.purple.application.util.IdGenerator;
 import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class RatingCreateApplicationService implements RatingCreateUseCase {
 
     @Override
     @Transactional
-    public Long create(Command command) {
+    public Rating create(Command command) {
         Long userId = getCurrentUserAuthentication().userId();
 
         return ratingDomainService.create(

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingCreateApplicationService.java
@@ -7,7 +7,7 @@ import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
 import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteCreateUseCase;
 import com.pikachu.purple.application.util.IdGenerator;
-import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingInfo;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -26,7 +26,7 @@ public class RatingCreateApplicationService implements RatingCreateUseCase {
     @Override
     @Transactional
     public void createOnboarding(OnboardingCommand command) {
-        List<Long> ratingIds = IntStream.range(0, command.ratingValues().size())
+        List<Long> ratingIds = IntStream.range(0, command.ratingInfos().size())
             .mapToObj(i -> IdGenerator.generate())
             .toList();
 
@@ -35,11 +35,11 @@ public class RatingCreateApplicationService implements RatingCreateUseCase {
         ratingDomainService.createOnboarding(
             ratingIds,
             userId,
-            command.ratingValues()
+            command.ratingInfos()
         );
 
-        List<Long> perfumeIds = command.ratingValues().stream()
-            .map(RatingValue::perfumeId)
+        List<Long> perfumeIds = command.ratingInfos().stream()
+            .map(RatingInfo::perfumeId)
             .toList();
 
         userPreferenceNoteCreateUseCase.invoke();

--- a/src/main/java/com/pikachu/purple/application/rating/service/application/RatingDeleteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/application/RatingDeleteApplicationService.java
@@ -2,26 +2,28 @@ package com.pikachu.purple.application.rating.service.application;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
-import com.pikachu.purple.application.rating.port.in.RatingUpdateUseCase;
+import com.pikachu.purple.application.rating.port.in.RatingDeleteUseCase;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
+import com.pikachu.purple.domain.rating.Rating;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class RatingUpdateApplicationService implements RatingUpdateUseCase {
+public class RatingDeleteApplicationService implements RatingDeleteUseCase {
 
     private final RatingDomainService ratingDomainService;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long ratingId) {
         Long userId = getCurrentUserAuthentication().userId();
 
-        ratingDomainService.updateScore(
-            userId,
-            command.ratingId(),
-            command.score()
+        Rating rating = ratingDomainService.getByIdAndUserId(
+            ratingId,
+            userId
         );
+
+        ratingDomainService.delete(rating);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.rating.service.domain;
 
-import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingInfo;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
@@ -9,7 +9,7 @@ public interface RatingDomainService {
     void createOnboarding(
         List<Long> ratingIds,
         Long userId,
-        List<RatingValue> ratingValues
+        List<RatingInfo> ratingInfos
     );
 
     Rating create(

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
@@ -12,7 +12,7 @@ public interface RatingDomainService {
         List<RatingValue> ratingValues
     );
 
-    Long create(
+    Rating create(
         Long ratingId,
         Long userId,
         Long perfumeId,

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/RatingDomainService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.rating.service.domain;
 
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 
@@ -9,23 +9,29 @@ public interface RatingDomainService {
     void createOnboarding(
         List<Long> ratingIds,
         Long userId,
-        List<Long> reviewIds,
         List<RatingValue> ratingValues
     );
 
-    void create(
+    Long create(
         Long ratingId,
         Long userId,
-        Long reviewId,
-        Double score
+        Long perfumeId,
+        int score
     );
 
     List<Rating> getAllByUserId(Long userId);
 
     void updateScore(
         Long userId,
-        Long reviewId,
-        Double score
+        Long ratingId,
+        int score
     );
+
+    Rating getByIdAndUserId(
+        Long ratingId,
+        Long userId
+    );
+
+    void delete(Rating rating);
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
@@ -2,7 +2,7 @@ package com.pikachu.purple.application.rating.service.domain.impl;
 
 import com.pikachu.purple.application.rating.port.out.RatingRepository;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
-import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingInfo;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -19,14 +19,14 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     public void createOnboarding(
         List<Long> ratingIds,
         Long userId,
-        List<RatingValue> ratingValues
+        List<RatingInfo> ratingInfos
     ) {
         List<Rating> ratings = IntStream.range(0, ratingIds.size())
             .mapToObj(i -> Rating.builder()
                 .ratingId(ratingIds.get(i))
                 .userId(userId)
-                .perfumeId(ratingValues.get(i).perfumeId())
-                .score(ratingValues.get(i).score())
+                .perfumeId(ratingInfos.get(i).perfumeId())
+                .score(ratingInfos.get(i).score())
                 .build())
             .toList();
 

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
@@ -2,7 +2,7 @@ package com.pikachu.purple.application.rating.service.domain.impl;
 
 import com.pikachu.purple.application.rating.port.out.RatingRepository;
 import com.pikachu.purple.application.rating.service.domain.RatingDomainService;
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
 import com.pikachu.purple.domain.rating.Rating;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -19,14 +19,13 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     public void createOnboarding(
         List<Long> ratingIds,
         Long userId,
-        List<Long> reviewIds,
         List<RatingValue> ratingValues
     ) {
         List<Rating> ratings = IntStream.range(0, ratingIds.size())
             .mapToObj(i -> Rating.builder()
                 .ratingId(ratingIds.get(i))
                 .userId(userId)
-                .reviewId(reviewIds.get(i))
+                .perfumeId(ratingValues.get(i).perfumeId())
                 .score(ratingValues.get(i).score())
                 .build())
             .toList();
@@ -35,20 +34,20 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     }
 
     @Override
-    public void create(
+    public Long create(
         Long ratingId,
         Long userId,
-        Long reviewId,
-        Double score
+        Long perfumeId,
+        int score
     ) {
         Rating rating = Rating.builder()
             .ratingId(ratingId)
             .userId(userId)
-            .reviewId(reviewId)
+            .perfumeId(perfumeId)
             .score(score)
             .build();
 
-        ratingRepository.create(rating);
+        return ratingRepository.create(rating);
     }
 
     @Override
@@ -59,17 +58,30 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     @Override
     public void updateScore(
         Long userId,
-        Long reviewId,
-        Double score
+        Long ratingId,
+        int score
     ) {
-        Rating rating = ratingRepository.getByUserIdAndReviewId(
-            userId,
-            reviewId
-        );
+        Rating rating = ratingRepository.getById(ratingId);
 
         rating.updateScore(score);
 
         ratingRepository.save(rating);
+    }
+
+    @Override
+    public Rating getByIdAndUserId(
+        Long ratingId,
+        Long userId
+    ) {
+        return ratingRepository.getByIdAndUserId(
+            ratingId,
+            userId
+        );
+    }
+
+    @Override
+    public void delete(Rating rating) {
+        ratingRepository.delete(rating);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/rating/service/domain/impl/RatingDomainServiceImpl.java
@@ -34,7 +34,7 @@ public class RatingDomainServiceImpl implements RatingDomainService {
     }
 
     @Override
-    public Long create(
+    public Rating create(
         Long ratingId,
         Long userId,
         Long perfumeId,

--- a/src/main/java/com/pikachu/purple/application/review/port/in/ReviewCreateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/ReviewCreateUseCase.java
@@ -1,21 +1,12 @@
 package com.pikachu.purple.application.review.port.in;
 
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
-import java.util.List;
-
 public interface ReviewCreateUseCase {
-
-    void createOnboarding(OnboardingCommand command);
 
     void create(Command command);
 
-    record OnboardingCommand(List<RatingValue> ratingValues) {
-
-    }
-
     record Command(
         Long perfumeId,
-        Double score,
+        int score,
         String content
     ) {
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/ReviewUpdateUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/ReviewUpdateUseCase.java
@@ -6,7 +6,8 @@ public interface ReviewUpdateUseCase {
 
     record Command(
         Long reviewId,
-        Double score,
+        Long ratingId,
+        int score,
         String content
     ) {
 

--- a/src/main/java/com/pikachu/purple/application/review/port/out/ReviewRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/ReviewRepository.java
@@ -7,7 +7,7 @@ public interface ReviewRepository {
 
     void createOnboarding(List<Review> reviews);
 
-    Long create(Review review);
+    void create(Review review);
 
     List<Review> findAllByUserId(Long userId);
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateApplicationService.java
@@ -2,15 +2,10 @@ package com.pikachu.purple.application.review.service.application;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
-import com.pikachu.purple.application.favorite.port.in.FavoriteCreateUseCase;
 import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
-import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteCreateUseCase;
 import com.pikachu.purple.application.util.IdGenerator;
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
-import java.util.List;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,58 +15,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewCreateApplicationService implements ReviewCreateUseCase {
 
     private final RatingCreateUseCase ratingCreateUseCase;
-    private final UserPreferenceNoteCreateUseCase userPreferenceNoteCreateUseCase;
-    private final FavoriteCreateUseCase favoriteCreateUseCase;
     private final ReviewDomainService reviewDomainService;
-
-    @Override
-    @Transactional
-    public void createOnboarding(OnboardingCommand command) {
-        Long userId = getCurrentUserAuthentication().userId();
-
-        List<Long> reviewIds = IntStream.range(0, command.ratingValues().size())
-            .mapToObj(i -> IdGenerator.generate())
-            .toList();
-
-        List<Long> perfumeIds = command.ratingValues().stream()
-            .map(RatingValue::perfumeId)
-            .toList();
-
-        reviewDomainService.createOnboarding(
-            reviewIds,
-            perfumeIds,
-            userId
-        );
-
-        ratingCreateUseCase.createOnboarding(
-            new RatingCreateUseCase.OnboardingCommand(
-                reviewIds,
-                command.ratingValues()
-            )
-        );
-
-        userPreferenceNoteCreateUseCase.invoke();
-        favoriteCreateUseCase.invoke(perfumeIds);
-    }
 
     @Override
     @Transactional
     public void create(Command command) {
         Long userId = getCurrentUserAuthentication().userId();
 
-        Long reviewId = reviewDomainService.create(
-            IdGenerator.generate(),
+        Long ratingId = ratingCreateUseCase.create(new RatingCreateUseCase.Command(
             command.perfumeId(),
-            userId,
-            command.content()
-        );
-
-        ratingCreateUseCase.create(new RatingCreateUseCase.Command(
-            reviewId,
             command.score()
         ));
 
-
+        reviewDomainService.create(
+            IdGenerator.generate(),
+            command.perfumeId(),
+            userId,
+            ratingId,
+            command.content()
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateApplicationService.java
@@ -6,6 +6,7 @@ import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.application.util.IdGenerator;
+import com.pikachu.purple.domain.rating.Rating;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class ReviewCreateApplicationService implements ReviewCreateUseCase {
     public void create(Command command) {
         Long userId = getCurrentUserAuthentication().userId();
 
-        Long ratingId = ratingCreateUseCase.create(new RatingCreateUseCase.Command(
+        Rating rating = ratingCreateUseCase.create(new RatingCreateUseCase.Command(
             command.perfumeId(),
             command.score()
         ));
@@ -31,7 +32,7 @@ public class ReviewCreateApplicationService implements ReviewCreateUseCase {
             IdGenerator.generate(),
             command.perfumeId(),
             userId,
-            ratingId,
+            rating.getRatingId(),
             command.content()
         );
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/ReviewDeleteApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/ReviewDeleteApplicationService.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.application.review.service.application;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
+import com.pikachu.purple.application.rating.port.in.RatingDeleteUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewDeleteUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.Review;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewDeleteApplicationService implements ReviewDeleteUseCase {
 
     private final ReviewDomainService reviewDomainService;
+    private final RatingDeleteUseCase ratingDeleteUseCase;
 
     @Override
     @Transactional
@@ -26,6 +28,8 @@ public class ReviewDeleteApplicationService implements ReviewDeleteUseCase {
         );
 
         reviewDomainService.delete(review);
+
+        ratingDeleteUseCase.invoke(review.getRatingId());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/ReviewUpdateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/ReviewUpdateApplicationService.java
@@ -29,7 +29,7 @@ public class ReviewUpdateApplicationService implements ReviewUpdateUseCase {
 
         ratingUpdateUseCase.invoke(
             new RatingUpdateUseCase.Command(
-                command.reviewId(),
+                command.ratingId(),
                 command.score()
             )
         );

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewDomainService.java
@@ -11,11 +11,12 @@ public interface ReviewDomainService {
         Long userId
     );
 
-    Long create(
+    void create(
         Long reviewId,
         Long perfumeId,
         Long userId,
-        String comment
+        Long ratingId,
+        String content
     );
 
     List<Review> findAllByUserId(Long userId);

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
@@ -3,7 +3,6 @@ package com.pikachu.purple.application.review.service.domain.impl;
 import com.pikachu.purple.application.review.port.out.ReviewRepository;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.Review;
-import com.pikachu.purple.infrastructure.persistence.common.ReviewType;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
@@ -27,7 +27,6 @@ public class ReviewDomainServiceImpl implements ReviewDomainService {
                 .perfumeId(perfumeIds.get(i))
                 .userId(userId)
                 .content("")
-                .reviewType(ReviewType.ONBOARDING)
                 .build())
             .toList();
 
@@ -35,21 +34,22 @@ public class ReviewDomainServiceImpl implements ReviewDomainService {
     }
 
     @Override
-    public Long create(
+    public void create(
         Long reviewId,
         Long perfumeId,
         Long userId,
+        Long ratingId,
         String content
     ) {
         Review review = Review.builder()
             .reviewId(reviewId)
             .perfumeId(perfumeId)
             .userId(userId)
+            .ratingId(ratingId)
             .content(content)
-            .reviewType(ReviewType.REVIEW)
             .build();
 
-        return reviewRepository.create(review);
+        reviewRepository.create(review);
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteCreateApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/userPreferenceNote/service/application/UserPreferenceNoteCreateApplicationService.java
@@ -2,7 +2,6 @@ package com.pikachu.purple.application.userPreferenceNote.service.application;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
-import com.pikachu.purple.application.review.port.in.ReviewGetUseCase;
 import com.pikachu.purple.application.userPreferenceNote.port.in.UserPreferenceNoteCreateUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeNoteGetUseCase;
 import com.pikachu.purple.application.perfume.util.RecommendNotesProvider;
@@ -12,7 +11,6 @@ import com.pikachu.purple.application.util.IdGenerator;
 import com.pikachu.purple.domain.note.Note;
 import com.pikachu.purple.domain.perfume.PerfumeNote;
 import com.pikachu.purple.domain.rating.Rating;
-import com.pikachu.purple.domain.review.Review;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +22,6 @@ public class UserPreferenceNoteCreateApplicationService implements
     UserPreferenceNoteCreateUseCase {
 
     private final RatingGetUseCase ratingGetUseCase;
-    private final ReviewGetUseCase reviewGetUseCase;
     private final PerfumeNoteGetUseCase perfumeNoteGetByRatingsUseCase;
     private final RecommendNotesProvider recommendNotesProvider;
     private final UserPreferenceNoteDomainService userPreferenceNoteDomainService;
@@ -33,17 +30,15 @@ public class UserPreferenceNoteCreateApplicationService implements
     public void invoke() {
         Long userId = getCurrentUserAuthentication().userId();
 
-        List<Review> reviews = reviewGetUseCase.findAllByUserId(userId);
         List<Rating> ratings = ratingGetUseCase.getAllByUserId(userId);
 
-        List<Long> perfumeIds = reviews.stream()
-            .map(Review::getPerfumeId)
+        List<Long> perfumeIds = ratings.stream()
+            .map(Rating::getPerfumeId)
             .toList();
 
         List<PerfumeNote> perfumeNotes = perfumeNoteGetByRatingsUseCase.getAllByPerfumeIds(perfumeIds);
 
         List<Note> topThreeNotes = recommendNotesProvider.getTopThreeNotes(
-            reviews,
             ratings,
             perfumeNotes
         );

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -121,7 +121,7 @@ public enum ErrorCode {
     RATING_NOT_FOUND(
         404,
         "RT001",
-        "해당하는 리뷰가 존재하지 않습니다."
+        "해당하는 별점이 존재하지 않습니다."
     );
 
     private final int status;

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Tag(name = "perfume", description = "perfume API")
+@Tag(name = "Perfume", description = "Perfume API")
 @RequestMapping(value = "/perpicks/perfumes", produces = "application/json")
 public interface PerfumeApi {
 

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/api/RatingApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/api/RatingApi.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Tag(name = "rating", description = "perfume API")
+@Tag(name = "Rating", description = "Rating API")
 @RequestMapping(value = "/perpicks/ratings", produces = "application/json")
 public interface RatingApi {
 

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/api/RatingApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/api/RatingApi.java
@@ -1,0 +1,33 @@
+package com.pikachu.purple.bootstrap.rating.api;
+
+import com.pikachu.purple.bootstrap.common.security.Secured;
+import com.pikachu.purple.bootstrap.rating.dto.request.RatingCreateOnboardingRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Tag(name = "rating", description = "perfume API")
+@RequestMapping(value = "/perpicks/ratings", produces = "application/json")
+public interface RatingApi {
+
+    @Secured
+    @Operation(summary = "온보딩에서 향수 평가 저장")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "204", description = "성공 시 상태코드(204)만 반환"
+            )
+        }
+    )
+    @PostMapping("/onboarding")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void createOnboarding(@RequestBody @Valid RatingCreateOnboardingRequest request);
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/controller/RatingController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/controller/RatingController.java
@@ -1,0 +1,24 @@
+package com.pikachu.purple.bootstrap.rating.controller;
+
+import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase;
+
+import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase.OnboardingCommand;
+import com.pikachu.purple.bootstrap.rating.api.RatingApi;
+import com.pikachu.purple.bootstrap.rating.dto.request.RatingCreateOnboardingRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RatingController implements RatingApi {
+
+    private final RatingCreateUseCase ratingCreateUseCase;
+
+    @Override
+    public void createOnboarding(RatingCreateOnboardingRequest request) {
+        ratingCreateUseCase.createOnboarding(
+            new OnboardingCommand(request.ratingValues())
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/controller/RatingController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/controller/RatingController.java
@@ -17,7 +17,7 @@ public class RatingController implements RatingApi {
     @Override
     public void createOnboarding(RatingCreateOnboardingRequest request) {
         ratingCreateUseCase.createOnboarding(
-            new OnboardingCommand(request.ratingValues())
+            new OnboardingCommand(request.ratingInfos())
         );
     }
 

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/dto/request/RatingCreateOnboardingRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/dto/request/RatingCreateOnboardingRequest.java
@@ -1,0 +1,9 @@
+package com.pikachu.purple.bootstrap.rating.dto.request;
+
+import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import jakarta.validation.Valid;
+import java.util.List;
+
+public record RatingCreateOnboardingRequest(@Valid List<RatingValue> ratingValues) {
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/dto/request/RatingCreateOnboardingRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/dto/request/RatingCreateOnboardingRequest.java
@@ -1,9 +1,9 @@
 package com.pikachu.purple.bootstrap.rating.dto.request;
 
-import com.pikachu.purple.bootstrap.rating.vo.RatingValue;
+import com.pikachu.purple.bootstrap.rating.vo.RatingInfo;
 import jakarta.validation.Valid;
 import java.util.List;
 
-public record RatingCreateOnboardingRequest(@Valid List<RatingValue> ratingValues) {
+public record RatingCreateOnboardingRequest(@Valid List<RatingInfo> ratingInfos) {
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingInfo.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingInfo.java
@@ -1,13 +1,11 @@
 package com.pikachu.purple.bootstrap.rating.vo;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import org.hibernate.validator.constraints.Range;
 
 public record RatingInfo(
     Long perfumeId,
     String perfumeName,
-    @Min(value = 1, message = "최소 값은 1입니다.")
-    @Max(value = 5, message = "최대 값은 5입니다.")
+    @Range(min = 1, max = 5)
     int score
 ) {
 

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingInfo.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingInfo.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.bootstrap.rating.vo;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
-public record RatingValue(
+public record RatingInfo(
     Long perfumeId,
     String perfumeName,
     @Min(value = 1, message = "최소 값은 1입니다.")

--- a/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingValue.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/rating/vo/RatingValue.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.bootstrap.rating.vo;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record RatingValue(
+    Long perfumeId,
+    String perfumeName,
+    @Min(value = 1, message = "최소 값은 1입니다.")
+    @Max(value = 5, message = "최대 값은 5입니다.")
+    int score
+) {
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Tag(name = "review", description = "review API")
+@Tag(name = "Review", description = "Review API")
 @RequestMapping(value = "/perpicks/reviews", produces = "application/json")
 public interface ReviewApi {
 

--- a/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
@@ -1,12 +1,9 @@
 package com.pikachu.purple.bootstrap.review.api;
 
 import com.pikachu.purple.bootstrap.common.security.Secured;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateOnboardingRequest;
 import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateRequest;
 import com.pikachu.purple.bootstrap.review.dto.request.ReviewUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -21,22 +18,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Tag(name = "review", description = "review API")
 @RequestMapping(value = "/perpicks/reviews", produces = "application/json")
 public interface ReviewApi {
-
-    @Secured
-    @Operation(summary = "온보딩에서 향수 평가 저장")
-    @ApiResponses(
-        value = {
-            @ApiResponse(
-                responseCode = "204", description = "성공 시 상태코드(204)만 반환"
-            ),
-            @ApiResponse(
-                responseCode = "404", description = "해당하는 리뷰가 존재하지 않습니다."
-            )
-        }
-    )
-    @PostMapping("/onboarding")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    void createOnboarding(@RequestBody ReviewCreateOnboardingRequest request);
 
     @Secured
     @Operation(summary = "향수 평가시 간단한 리뷰 작성")

--- a/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
@@ -1,11 +1,9 @@
 package com.pikachu.purple.bootstrap.review.controller;
 
 import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase;
-import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase.OnboardingCommand;
 import com.pikachu.purple.application.review.port.in.ReviewDeleteUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewUpdateUseCase;
 import com.pikachu.purple.bootstrap.review.api.ReviewApi;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateOnboardingRequest;
 import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateRequest;
 import com.pikachu.purple.bootstrap.review.dto.request.ReviewUpdateRequest;
 import lombok.RequiredArgsConstructor;
@@ -20,13 +18,6 @@ public class ReviewController implements ReviewApi {
     private final ReviewDeleteUseCase reviewDeleteUseCase;
 
     @Override
-    public void createOnboarding(ReviewCreateOnboardingRequest request) {
-        reviewCreateUseCase.createOnboarding(
-            new OnboardingCommand(request.ratingValues())
-        );
-    }
-
-    @Override
     public void create(ReviewCreateRequest request) {
         reviewCreateUseCase.create(
             new ReviewCreateUseCase.Command(
@@ -35,7 +26,6 @@ public class ReviewController implements ReviewApi {
                 request.content()
             )
         );
-
     }
 
     @Override
@@ -46,6 +36,7 @@ public class ReviewController implements ReviewApi {
         reviewUpdateUseCase.invoke(
             new ReviewUpdateUseCase.Command(
                 reviewId,
+                request.ratingId(),
                 request.score(),
                 request.content()
             )

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateOnboardingRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateOnboardingRequest.java
@@ -1,8 +1,0 @@
-package com.pikachu.purple.bootstrap.review.dto.request;
-
-import com.pikachu.purple.bootstrap.review.vo.RatingValue;
-import java.util.List;
-
-public record ReviewCreateOnboardingRequest(List<RatingValue> ratingValues) {
-
-}

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateRequest.java
@@ -1,13 +1,11 @@
 package com.pikachu.purple.bootstrap.review.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 
 public record ReviewCreateRequest(
     Long perfumeId,
-    @Min(value = 1, message = "최소 값은 1입니다.")
-    @Max(value = 5, message = "최대 값은 5입니다.")
+    @Range(min = 1, max = 5)
     int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")
     String content

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewCreateRequest.java
@@ -1,10 +1,14 @@
 package com.pikachu.purple.bootstrap.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record ReviewCreateRequest(
     Long perfumeId,
-    Double score,
+    @Min(value = 1, message = "최소 값은 1입니다.")
+    @Max(value = 5, message = "최대 값은 5입니다.")
+    int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")
     String content
 ) {

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewUpdateRequest.java
@@ -1,9 +1,14 @@
 package com.pikachu.purple.bootstrap.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record ReviewUpdateRequest (
-    Double score,
+    Long ratingId,
+    @Min(value = 1, message = "최소 값은 1입니다.")
+    @Max(value = 5, message = "최대 값은 5입니다.")
+    int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")
     String content
 ) {

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/ReviewUpdateRequest.java
@@ -1,13 +1,11 @@
 package com.pikachu.purple.bootstrap.review.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.Range;
 
 public record ReviewUpdateRequest (
     Long ratingId,
-    @Min(value = 1, message = "최소 값은 1입니다.")
-    @Max(value = 5, message = "최대 값은 5입니다.")
+    @Range(min = 1, max = 5)
     int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")
     String content

--- a/src/main/java/com/pikachu/purple/bootstrap/review/vo/RatingValue.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/vo/RatingValue.java
@@ -1,9 +1,0 @@
-package com.pikachu.purple.bootstrap.review.vo;
-
-public record RatingValue(
-    Long perfumeId,
-    String perfumeName,
-    Double score
-) {
-
-}

--- a/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
+++ b/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
@@ -12,7 +12,6 @@ public class Favorite {
     private Long favoriteId;
     private Long userId;
     private Long perfumeId;
-    private boolean active;
 
     @Builder
     public Favorite(
@@ -23,6 +22,6 @@ public class Favorite {
         this.favoriteId = favoriteId;
         this.userId = userId;
         this.perfumeId = perfumeId;
-        this.active = true;
     }
+
 }

--- a/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
+++ b/src/main/java/com/pikachu/purple/domain/favorite/Favorite.java
@@ -1,6 +1,5 @@
 package com.pikachu.purple.domain.favorite;
 
-import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,18 +12,17 @@ public class Favorite {
     private Long favoriteId;
     private Long userId;
     private Long perfumeId;
-    private EntityStatus entityStatus;
+    private boolean active;
 
     @Builder
     public Favorite(
         Long favoriteId,
         Long userId,
-        Long perfumeId,
-        EntityStatus entityStatus
+        Long perfumeId
     ) {
         this.favoriteId = favoriteId;
         this.userId = userId;
         this.perfumeId = perfumeId;
-        this.entityStatus = entityStatus;
+        this.active = true;
     }
 }

--- a/src/main/java/com/pikachu/purple/domain/rating/Rating.java
+++ b/src/main/java/com/pikachu/purple/domain/rating/Rating.java
@@ -13,7 +13,6 @@ public class Rating {
     private Long userId;
     private Long perfumeId;
     private int score;
-    private boolean active;
 
     @Builder
     public Rating(
@@ -26,7 +25,6 @@ public class Rating {
         this.userId = userId;
         this.perfumeId = perfumeId;
         this.score = score;
-        this.active = true;
     }
 
     public void updateScore(int score) {

--- a/src/main/java/com/pikachu/purple/domain/rating/Rating.java
+++ b/src/main/java/com/pikachu/purple/domain/rating/Rating.java
@@ -1,6 +1,5 @@
 package com.pikachu.purple.domain.rating;
 
-import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,26 +11,26 @@ public class Rating {
 
     private Long ratingId;
     private Long userId;
-    private Long reviewId;
-    private Double score;
-    private EntityStatus entityStatus;
+    private Long perfumeId;
+    private int score;
+    private boolean active;
 
     @Builder
     public Rating(
         Long ratingId,
         Long userId,
-        Long reviewId,
-        Double score
+        Long perfumeId,
+        int score
     ){
         this.ratingId = ratingId;
         this.userId = userId;
-        this.reviewId = reviewId;
+        this.perfumeId = perfumeId;
         this.score = score;
-        this.entityStatus = EntityStatus.ACTIVE;
+        this.active = true;
     }
 
-    public void updateScore(Double score) {
-        this.score = (score != null) ? score : this.score;
+    public void updateScore(int score) {
+        this.score = score;
     }
 
 }

--- a/src/main/java/com/pikachu/purple/domain/review/Review.java
+++ b/src/main/java/com/pikachu/purple/domain/review/Review.java
@@ -1,6 +1,5 @@
 package com.pikachu.purple.domain.review;
 
-import com.pikachu.purple.infrastructure.persistence.common.ReviewType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,22 +12,24 @@ public class Review {
     private Long reviewId;
     private Long perfumeId;
     private Long userId;
+    private Long ratingId;
     private String content;
-    private ReviewType reviewType;
+    private boolean active;
 
     @Builder
     public Review(
         Long reviewId,
         Long perfumeId,
         Long userId,
-        String content,
-        ReviewType reviewType
+        Long ratingId,
+        String content
     ) {
         this.reviewId = reviewId;
         this.perfumeId = perfumeId;
         this.userId = userId;
+        this.ratingId = ratingId;
         this.content = content;
-        this.reviewType = reviewType;
+        this.active = true;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/pikachu/purple/domain/review/Review.java
+++ b/src/main/java/com/pikachu/purple/domain/review/Review.java
@@ -14,7 +14,6 @@ public class Review {
     private Long userId;
     private Long ratingId;
     private String content;
-    private boolean active;
 
     @Builder
     public Review(
@@ -29,7 +28,6 @@ public class Review {
         this.userId = userId;
         this.ratingId = ratingId;
         this.content = content;
-        this.active = true;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/common/BaseEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/common/BaseEntity.java
@@ -21,4 +21,6 @@ public abstract class BaseEntity{
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    private boolean isActive = true;
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
@@ -2,22 +2,23 @@ package com.pikachu.purple.infrastructure.persistence.favorite.entity;
 
 import com.pikachu.purple.domain.favorite.Favorite;
 import com.pikachu.purple.infrastructure.persistence.common.BaseEntity;
-import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @Table(name = "favorite")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE favorite SET active = false WHERE favorite_id = ?")
+@Where(clause = "active = true")
 public class FavoriteJpaEntity extends BaseEntity {
 
     @Id
@@ -30,21 +31,19 @@ public class FavoriteJpaEntity extends BaseEntity {
     @Column(name = "perfume_id")
     private Long perfumeId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "entity_status")
-    private EntityStatus entityStatus;
+    private boolean active;
 
     @Builder
     public FavoriteJpaEntity(
         Long favoriteId,
         Long userId,
         Long perfumeId,
-        EntityStatus entityStatus
+        boolean active
     ) {
         this.favoriteId = favoriteId;
         this.userId = userId;
         this.perfumeId = perfumeId;
-        this.entityStatus = entityStatus;
+        this.active = active;
     }
 
     public static FavoriteJpaEntity toJpaEntity(Favorite favorite) {
@@ -52,7 +51,7 @@ public class FavoriteJpaEntity extends BaseEntity {
             .favoriteId(favorite.getFavoriteId())
             .userId(favorite.getUserId())
             .perfumeId(favorite.getPerfumeId())
-            .entityStatus(favorite.getEntityStatus())
+            .active(favorite.isActive())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/favorite/entity/FavoriteJpaEntity.java
@@ -11,14 +11,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @Table(name = "favorite")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE favorite SET active = false WHERE favorite_id = ?")
-@Where(clause = "active = true")
+@SQLDelete(sql = "UPDATE favorite SET is_active = false WHERE favorite_id = ?")
+@SQLRestriction("is_active = true")
 public class FavoriteJpaEntity extends BaseEntity {
 
     @Id
@@ -31,19 +31,15 @@ public class FavoriteJpaEntity extends BaseEntity {
     @Column(name = "perfume_id")
     private Long perfumeId;
 
-    private boolean active;
-
     @Builder
     public FavoriteJpaEntity(
         Long favoriteId,
         Long userId,
-        Long perfumeId,
-        boolean active
+        Long perfumeId
     ) {
         this.favoriteId = favoriteId;
         this.userId = userId;
         this.perfumeId = perfumeId;
-        this.active = active;
     }
 
     public static FavoriteJpaEntity toJpaEntity(Favorite favorite) {
@@ -51,7 +47,6 @@ public class FavoriteJpaEntity extends BaseEntity {
             .favoriteId(favorite.getFavoriteId())
             .userId(favorite.getUserId())
             .perfumeId(favorite.getPerfumeId())
-            .active(favorite.isActive())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
@@ -27,9 +27,9 @@ public class RatingJpaAdaptor implements RatingRepository {
     }
 
     @Override
-    public void create(Rating rating) {
+    public Long create(Rating rating) {
         RatingJpaEntity ratingJpaEntity = RatingJpaEntity.toJpaEntity(rating);
-        ratingJpaRepository.save(ratingJpaEntity);
+        return ratingJpaRepository.save(ratingJpaEntity).getRatingId();
     }
 
     @Override
@@ -42,11 +42,9 @@ public class RatingJpaAdaptor implements RatingRepository {
     }
 
     @Override
-    public Rating getByUserIdAndReviewId(Long userId, Long reviewId) {
-        RatingJpaEntity ratingJpaEntity = ratingJpaRepository.findByUserIdAndReviewId(
-            userId,
-            reviewId
-        ).orElseThrow(() -> RatingNotFoundException);
+    public Rating getById(Long ratingId) {
+        RatingJpaEntity ratingJpaEntity = ratingJpaRepository.findById(ratingId)
+            .orElseThrow(() -> RatingNotFoundException);
 
         return RatingJpaEntity.toDomain(ratingJpaEntity);
     }
@@ -55,6 +53,25 @@ public class RatingJpaAdaptor implements RatingRepository {
     public void save(Rating rating) {
         RatingJpaEntity ratingJpaEntity = RatingJpaEntity.toJpaEntity(rating);
         ratingJpaRepository.save(ratingJpaEntity);
+    }
+
+    @Override
+    public Rating getByIdAndUserId(
+        Long ratingId,
+        Long userId
+    ) {
+        RatingJpaEntity ratingJpaEntity = ratingJpaRepository.findByRatingIdAndUserId(
+            ratingId,
+            userId
+        ).orElseThrow(() -> RatingNotFoundException);
+
+        return RatingJpaEntity.toDomain(ratingJpaEntity);
+    }
+
+    @Override
+    public void delete(Rating rating) {
+        RatingJpaEntity ratingJpaEntity = RatingJpaEntity.toJpaEntity(rating);
+        ratingJpaRepository.delete(ratingJpaEntity);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/adaptor/RatingJpaAdaptor.java
@@ -27,9 +27,10 @@ public class RatingJpaAdaptor implements RatingRepository {
     }
 
     @Override
-    public Long create(Rating rating) {
+    public Rating create(Rating rating) {
         RatingJpaEntity ratingJpaEntity = RatingJpaEntity.toJpaEntity(rating);
-        return ratingJpaRepository.save(ratingJpaEntity).getRatingId();
+
+        return RatingJpaEntity.toDomain(ratingJpaRepository.save(ratingJpaEntity));
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/entity/RatingJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/entity/RatingJpaEntity.java
@@ -11,14 +11,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @Table(name = "rating")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE rating SET active = false WHERE rating_id = ?")
-@Where(clause = "active = true")
+@SQLDelete(sql = "UPDATE rating SET is_active = false WHERE rating_id = ?")
+@SQLRestriction("is_active = true")
 public class RatingJpaEntity extends BaseEntity {
 
     @Id
@@ -34,22 +34,17 @@ public class RatingJpaEntity extends BaseEntity {
     @Column(nullable = false)
     private int score;
 
-    @Column(nullable = false)
-    private boolean active;
-
     @Builder
     public RatingJpaEntity(
         Long ratingId,
         Long userId,
         Long perfumeId,
-        int score,
-        boolean active
+        int score
     ) {
         this.ratingId = ratingId;
         this.userId = userId;
         this.perfumeId = perfumeId;
         this.score = score;
-        this.active = active;
     }
 
 
@@ -68,7 +63,6 @@ public class RatingJpaEntity extends BaseEntity {
             .userId(rating.getUserId())
             .perfumeId(rating.getPerfumeId())
             .score(rating.getScore())
-            .active(rating.isActive())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/entity/RatingJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/entity/RatingJpaEntity.java
@@ -2,22 +2,23 @@ package com.pikachu.purple.infrastructure.persistence.rating.entity;
 
 import com.pikachu.purple.domain.rating.Rating;
 import com.pikachu.purple.infrastructure.persistence.common.BaseEntity;
-import com.pikachu.purple.infrastructure.persistence.common.EntityStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @Table(name = "rating")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE rating SET active = false WHERE rating_id = ?")
+@Where(clause = "active = true")
 public class RatingJpaEntity extends BaseEntity {
 
     @Id
@@ -27,29 +28,28 @@ public class RatingJpaEntity extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "review_id", nullable = false)
-    private Long reviewId;
+    @Column(name = "perfume_id", nullable = false)
+    private Long perfumeId;
 
     @Column(nullable = false)
-    private Double score;
+    private int score;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "entity_status")
-    private EntityStatus entityStatus;
+    @Column(nullable = false)
+    private boolean active;
 
     @Builder
     public RatingJpaEntity(
         Long ratingId,
         Long userId,
-        Long reviewId,
-        Double score,
-        EntityStatus entityStatus
+        Long perfumeId,
+        int score,
+        boolean active
     ) {
         this.ratingId = ratingId;
         this.userId = userId;
-        this.reviewId = reviewId;
+        this.perfumeId = perfumeId;
         this.score = score;
-        this.entityStatus = entityStatus;
+        this.active = active;
     }
 
 
@@ -57,7 +57,7 @@ public class RatingJpaEntity extends BaseEntity {
         return Rating.builder()
             .ratingId(ratingJpaEntity.getRatingId())
             .userId(ratingJpaEntity.getUserId())
-            .reviewId(ratingJpaEntity.getReviewId())
+            .perfumeId(ratingJpaEntity.getPerfumeId())
             .score(ratingJpaEntity.getScore())
             .build();
     }
@@ -66,9 +66,9 @@ public class RatingJpaEntity extends BaseEntity {
         return RatingJpaEntity.builder()
             .ratingId(rating.getRatingId())
             .userId(rating.getUserId())
-            .reviewId(rating.getReviewId())
+            .perfumeId(rating.getPerfumeId())
             .score(rating.getScore())
-            .entityStatus(rating.getEntityStatus())
+            .active(rating.isActive())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/rating/repository/RatingJpaRepository.java
@@ -11,5 +11,9 @@ public interface RatingJpaRepository extends JpaRepository<RatingJpaEntity, Long
 
     List<RatingJpaEntity> findByUserId(Long userId);
 
-    Optional<RatingJpaEntity> findByUserIdAndReviewId(Long userId, Long reviewId);
+   Optional<RatingJpaEntity> findByRatingIdAndUserId(
+       Long ratingId,
+       Long userId
+   );
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
@@ -26,9 +26,9 @@ public class ReviewJpaAdaptor implements ReviewRepository {
     }
 
     @Override
-    public Long create(Review review) {
+    public void create(Review review) {
         ReviewJpaEntity reviewJpaEntity = ReviewJpaEntity.toJpaEntity(review);
-        return reviewJpaRepository.save(reviewJpaEntity).getReviewId();
+        reviewJpaRepository.save(reviewJpaEntity);
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/ReviewJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/ReviewJpaEntity.java
@@ -2,22 +2,23 @@ package com.pikachu.purple.infrastructure.persistence.review.entity;
 
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.infrastructure.persistence.common.BaseEntity;
-import com.pikachu.purple.infrastructure.persistence.common.ReviewType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @Table(name = "review")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE review SET active = false WHERE review_id = ?")
+@Where(clause = "active = true")
 public class ReviewJpaEntity extends BaseEntity {
 
     @Id
@@ -30,26 +31,29 @@ public class ReviewJpaEntity extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Column(name = "rating_id", nullable = false)
+    private Long ratingId;
+
     @Column(name = "content", nullable = false)
     private String content;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "review_type")
-    private ReviewType reviewType;
+    private boolean active;
 
     @Builder
     public ReviewJpaEntity(
         Long reviewId,
         Long perfumeId,
         Long userId,
+        Long ratingId,
         String content,
-        ReviewType reviewType
+        boolean active
     ) {
         this.reviewId = reviewId;
         this.perfumeId = perfumeId;
         this.userId = userId;
+        this.ratingId = ratingId;
         this.content = content;
-        this.reviewType = reviewType;
+        this.active = active;
     }
 
     public static ReviewJpaEntity toJpaEntity(Review review) {
@@ -57,8 +61,9 @@ public class ReviewJpaEntity extends BaseEntity {
             .reviewId(review.getReviewId())
             .perfumeId(review.getPerfumeId())
             .userId(review.getUserId())
+            .ratingId(review.getRatingId())
             .content(review.getContent())
-            .reviewType(review.getReviewType())
+            .active(review.isActive())
             .build();
     }
 
@@ -67,8 +72,8 @@ public class ReviewJpaEntity extends BaseEntity {
             .reviewId(reviewJpaEntity.getReviewId())
             .perfumeId(reviewJpaEntity.getPerfumeId())
             .userId(reviewJpaEntity.getUserId())
+            .ratingId(reviewJpaEntity.getRatingId())
             .content(reviewJpaEntity.getContent())
-            .reviewType(reviewJpaEntity.getReviewType())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/ReviewJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/ReviewJpaEntity.java
@@ -11,14 +11,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @Table(name = "review")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE review SET active = false WHERE review_id = ?")
-@Where(clause = "active = true")
+@SQLDelete(sql = "UPDATE review SET is_active = false WHERE review_id = ?")
+@SQLRestriction("is_active = true")
 public class ReviewJpaEntity extends BaseEntity {
 
     @Id
@@ -37,23 +37,19 @@ public class ReviewJpaEntity extends BaseEntity {
     @Column(name = "content", nullable = false)
     private String content;
 
-    private boolean active;
-
     @Builder
     public ReviewJpaEntity(
         Long reviewId,
         Long perfumeId,
         Long userId,
         Long ratingId,
-        String content,
-        boolean active
+        String content
     ) {
         this.reviewId = reviewId;
         this.perfumeId = perfumeId;
         this.userId = userId;
         this.ratingId = ratingId;
         this.content = content;
-        this.active = active;
     }
 
     public static ReviewJpaEntity toJpaEntity(Review review) {
@@ -63,7 +59,6 @@ public class ReviewJpaEntity extends BaseEntity {
             .userId(review.getUserId())
             .ratingId(review.getRatingId())
             .content(review.getContent())
-            .active(review.isActive())
             .build();
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/ReviewJpaRepository.java
@@ -11,6 +11,9 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long
 
     List<ReviewJpaEntity> findByUserId(Long userId);
 
-    Optional<ReviewJpaEntity> findByReviewIdAndUserId(Long reviewId, Long userId);
+    Optional<ReviewJpaEntity> findByReviewIdAndUserId(
+        Long reviewId,
+        Long userId
+    );
 
 }


### PR DESCRIPTION
### 진행상황
- favorite, review, rating에 soft delete를 적용하였습니다.
- rating의 pk가 review의 fk로 변경되면서 온보딩 로직을 변경하였습니다.
- 별점값이 1~5 사이 정수로 정책이 변경되어 적용했습니다.

### 추후 pr
- 별점 집계 api 구현