### PR TITLE
[PURPLE-126] 자세한 코멘트 평가 항목(field, option) 정보 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,6 @@ dependencies {
 
     // S3
     implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
-
-    // elasticSearch
-    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationFieldDTO.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationFieldDTO.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.evaluation.common.dto;
+
+import java.util.List;
+
+public record EvaluationFieldDTO(
+    String fieldCode,
+    String fieldName,
+    List<EvaluationOptionDTO> evaluationOptionDTOs
+) {
+
+    public static EvaluationFieldDTO from(
+        String fieldCode,
+        String fieldName,
+        List<EvaluationOptionDTO> evaluationOptionDTOS
+    ) {
+        return new EvaluationFieldDTO(
+            fieldCode,
+            fieldName,
+            evaluationOptionDTOS
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationFieldDTO.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationFieldDTO.java
@@ -8,7 +8,7 @@ public record EvaluationFieldDTO(
     List<EvaluationOptionDTO> evaluationOptionDTOs
 ) {
 
-    public static EvaluationFieldDTO from(
+    public static EvaluationFieldDTO of(
         String fieldCode,
         String fieldName,
         List<EvaluationOptionDTO> evaluationOptionDTOS

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationOptionDTO.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationOptionDTO.java
@@ -5,7 +5,7 @@ public record EvaluationOptionDTO(
     String optionName
 ) {
 
-    public static EvaluationOptionDTO from(
+    public static EvaluationOptionDTO of(
         String optionCode,
         String optionName
     ) {

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationOptionDTO.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/EvaluationOptionDTO.java
@@ -1,0 +1,18 @@
+package com.pikachu.purple.application.evaluation.common.dto;
+
+public record EvaluationOptionDTO(
+    String optionCode,
+    String optionName
+) {
+
+    public static EvaluationOptionDTO from(
+        String optionCode,
+        String optionName
+    ) {
+        return new EvaluationOptionDTO(
+            optionCode,
+            optionName
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/in/EvaluationCodeGetUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/in/EvaluationCodeGetUseCase.java
@@ -1,0 +1,18 @@
+package com.pikachu.purple.application.evaluation.port.in;
+
+import com.pikachu.purple.application.evaluation.common.dto.EvaluationFieldDTO;
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+
+public interface EvaluationCodeGetUseCase {
+
+    Result invoke();
+
+    record Result(
+        List<EvaluationFieldDTO> evaluationFieldDTOS,
+        List<EvaluationMood> evaluationMoods
+    ) {
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationCodeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationCodeRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.port.out;
+
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import java.util.List;
+
+public interface EvaluationCodeRepository {
+
+    List<EvaluationCode> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationFieldOptionRepository.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationFieldOptionRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.port.out;
+
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
+import java.util.List;
+
+public interface EvaluationFieldOptionRepository {
+
+    List<EvaluationFieldOption> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationMoodRepository.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/out/EvaluationMoodRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.port.out;
+
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+
+public interface EvaluationMoodRepository {
+
+    List<EvaluationMood> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/EvaluationCodeGetApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/EvaluationCodeGetApplicationService.java
@@ -1,0 +1,60 @@
+package com.pikachu.purple.application.evaluation.service.application;
+
+import com.pikachu.purple.application.evaluation.common.dto.EvaluationFieldDTO;
+import com.pikachu.purple.application.evaluation.common.dto.EvaluationOptionDTO;
+import com.pikachu.purple.application.evaluation.port.in.EvaluationCodeGetUseCase;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationCodeDomainService;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationFieldOptionDomainService;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationMoodDomainService;
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationCodeGetApplicationService implements EvaluationCodeGetUseCase {
+
+    private final EvaluationCodeDomainService evaluationCodeDomainService;
+    private final EvaluationFieldOptionDomainService evaluationFieldOptionDomainService;
+    private final EvaluationMoodDomainService evaluationMoodDomainService;
+
+    @Override
+    public Result invoke() {
+        List<EvaluationCode> evaluationCodes = evaluationCodeDomainService.findAll();
+        List<EvaluationFieldOption> evaluationFieldOptions = evaluationFieldOptionDomainService.findAll();
+        List<EvaluationMood> evaluationMoods = evaluationMoodDomainService.findAll();
+
+        Map<String, String> codeMap = evaluationCodes.stream()
+            .collect(Collectors.toMap(
+                    EvaluationCode::getCode,
+                    EvaluationCode::getName
+                ));
+
+        Map<String, List<EvaluationFieldOption>> groupByFieldMap = evaluationFieldOptions.stream()
+            .collect(Collectors.groupingBy(EvaluationFieldOption::getFieldCode));
+
+        List<EvaluationFieldDTO> evaluationFieldDTOs = groupByFieldMap.entrySet().stream()
+            .map(entry -> EvaluationFieldDTO.from(
+                entry.getKey(),
+                codeMap.get(entry.getKey()),
+                entry.getValue().stream()
+                    .map(option -> EvaluationOptionDTO.from(
+                        option.getOptionCode(),
+                        codeMap.get(option.getOptionCode())
+                    ))
+                    .toList()
+            ))
+            .toList();
+
+        return new Result(
+            evaluationFieldDTOs,
+            evaluationMoods
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/EvaluationCodeGetApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/EvaluationCodeGetApplicationService.java
@@ -39,11 +39,11 @@ public class EvaluationCodeGetApplicationService implements EvaluationCodeGetUse
             .collect(Collectors.groupingBy(EvaluationFieldOption::getFieldCode));
 
         List<EvaluationFieldDTO> evaluationFieldDTOs = groupByFieldMap.entrySet().stream()
-            .map(entry -> EvaluationFieldDTO.from(
+            .map(entry -> EvaluationFieldDTO.of(
                 entry.getKey(),
                 codeMap.get(entry.getKey()),
                 entry.getValue().stream()
-                    .map(option -> EvaluationOptionDTO.from(
+                    .map(option -> EvaluationOptionDTO.of(
                         option.getOptionCode(),
                         codeMap.get(option.getOptionCode())
                     ))

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationCodeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationCodeDomainService.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.service.domain;
+
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import java.util.List;
+
+public interface EvaluationCodeDomainService {
+
+    List<EvaluationCode> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationFieldOptionDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationFieldOptionDomainService.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.service.domain;
+
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
+import java.util.List;
+
+public interface EvaluationFieldOptionDomainService {
+
+    List<EvaluationFieldOption> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationMoodDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/EvaluationMoodDomainService.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.application.evaluation.service.domain;
+
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+
+public interface EvaluationMoodDomainService {
+
+    List<EvaluationMood> findAll();
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationCodeDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationCodeDomainServiceImpl.java
@@ -1,0 +1,21 @@
+package com.pikachu.purple.application.evaluation.service.domain.impl;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationCodeRepository;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationCodeDomainService;
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationCodeDomainServiceImpl implements EvaluationCodeDomainService {
+
+    private final EvaluationCodeRepository evaluationCodeRepository;
+
+    @Override
+    public List<EvaluationCode> findAll() {
+        return evaluationCodeRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationFieldOptionDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationFieldOptionDomainServiceImpl.java
@@ -1,0 +1,21 @@
+package com.pikachu.purple.application.evaluation.service.domain.impl;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationFieldOptionRepository;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationFieldOptionDomainService;
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationFieldOptionDomainServiceImpl implements EvaluationFieldOptionDomainService {
+
+    private final EvaluationFieldOptionRepository evaluationFieldOptionRepository;
+
+    @Override
+    public List<EvaluationFieldOption> findAll() {
+        return evaluationFieldOptionRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationMoodDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/EvaluationMoodDomainServiceImpl.java
@@ -1,0 +1,20 @@
+package com.pikachu.purple.application.evaluation.service.domain.impl;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationMoodRepository;
+import com.pikachu.purple.application.evaluation.service.domain.EvaluationMoodDomainService;
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationMoodDomainServiceImpl implements EvaluationMoodDomainService {
+
+    private final EvaluationMoodRepository evaluationMoodRepository;
+
+    @Override
+    public List<EvaluationMood> findAll() {
+        return evaluationMoodRepository.findAll();
+    }
+}

--- a/src/main/java/com/pikachu/purple/application/review/port/in/ReviewCreateSimpleUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/ReviewCreateSimpleUseCase.java
@@ -1,8 +1,8 @@
 package com.pikachu.purple.application.review.port.in;
 
-public interface ReviewCreateUseCase {
+public interface ReviewCreateSimpleUseCase {
 
-    void create(Command command);
+    void invoke(Command command);
 
     record Command(
         Long perfumeId,

--- a/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/ReviewCreateSimpleApplicationService.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.application.review.service.application;
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
 import com.pikachu.purple.application.rating.port.in.RatingCreateUseCase;
-import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase;
+import com.pikachu.purple.application.review.port.in.ReviewCreateSimpleUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.application.util.IdGenerator;
 import com.pikachu.purple.domain.rating.Rating;
@@ -13,14 +13,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ReviewCreateApplicationService implements ReviewCreateUseCase {
+public class ReviewCreateSimpleApplicationService implements ReviewCreateSimpleUseCase {
 
     private final RatingCreateUseCase ratingCreateUseCase;
     private final ReviewDomainService reviewDomainService;
 
     @Override
     @Transactional
-    public void create(Command command) {
+    public void invoke(Command command) {
         Long userId = getCurrentUserAuthentication().userId();
 
         Rating rating = ratingCreateUseCase.create(new RatingCreateUseCase.Command(

--- a/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
@@ -1,13 +1,16 @@
 package com.pikachu.purple.bootstrap.review.api;
 
+import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.common.security.Secured;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateRequest;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewUpdateRequest;
+import com.pikachu.purple.bootstrap.review.dto.request.CreateReviewSimpleRequest;
+import com.pikachu.purple.bootstrap.review.dto.request.UpdateReviewSimpleRequest;
+import com.pikachu.purple.bootstrap.review.dto.response.GetReviewDetailInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,9 +24,17 @@ public interface ReviewApi {
 
     @Secured
     @Operation(summary = "향수 평가시 간단한 리뷰 작성")
-    @PostMapping
+    @PostMapping("/simple")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    void create(@RequestBody @Valid ReviewCreateRequest request);
+    void createSimple(@RequestBody @Valid CreateReviewSimpleRequest request);
+
+    @Operation(
+        summary = "자세한 리뷰 평가 항목 정보 조회",
+        description = "지속력, 시야주, 계절감/시간, 성별, 분위기"
+    )
+    @GetMapping("/detail")
+    @ResponseStatus(HttpStatus.OK)
+    SuccessResponse<GetReviewDetailInfoResponse> getDetailInfo();
 
     @Secured
     @Operation(summary = "자신이 작성한 리뷰 내용 및 별점 수정")
@@ -31,7 +42,7 @@ public interface ReviewApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void update(
         @PathVariable("review-id") Long reviewId,
-        @RequestBody @Valid ReviewUpdateRequest request
+        @RequestBody @Valid UpdateReviewSimpleRequest request
     );
 
     @Secured

--- a/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/api/ReviewApi.java
@@ -32,7 +32,7 @@ public interface ReviewApi {
         summary = "자세한 리뷰 평가 항목 정보 조회",
         description = "지속력, 시야주, 계절감/시간, 성별, 분위기"
     )
-    @GetMapping("/detail")
+    @GetMapping("/evaluation-fields")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<GetReviewDetailInfoResponse> getDetailInfo();
 

--- a/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
@@ -1,11 +1,15 @@
 package com.pikachu.purple.bootstrap.review.controller;
 
-import com.pikachu.purple.application.review.port.in.ReviewCreateUseCase;
+import com.pikachu.purple.application.evaluation.port.in.EvaluationCodeGetUseCase;
+import com.pikachu.purple.application.evaluation.port.in.EvaluationCodeGetUseCase.Result;
+import com.pikachu.purple.application.review.port.in.ReviewCreateSimpleUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewDeleteUseCase;
 import com.pikachu.purple.application.review.port.in.ReviewUpdateUseCase;
+import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.review.api.ReviewApi;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewCreateRequest;
-import com.pikachu.purple.bootstrap.review.dto.request.ReviewUpdateRequest;
+import com.pikachu.purple.bootstrap.review.dto.request.CreateReviewSimpleRequest;
+import com.pikachu.purple.bootstrap.review.dto.request.UpdateReviewSimpleRequest;
+import com.pikachu.purple.bootstrap.review.dto.response.GetReviewDetailInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,14 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewController implements ReviewApi {
 
-    private final ReviewCreateUseCase reviewCreateUseCase;
+    private final ReviewCreateSimpleUseCase reviewCreateSimpleUseCase;
+    private final EvaluationCodeGetUseCase evaluationCodeGetUseCase;
     private final ReviewUpdateUseCase reviewUpdateUseCase;
     private final ReviewDeleteUseCase reviewDeleteUseCase;
 
     @Override
-    public void create(ReviewCreateRequest request) {
-        reviewCreateUseCase.create(
-            new ReviewCreateUseCase.Command(
+    public void createSimple(CreateReviewSimpleRequest request) {
+        reviewCreateSimpleUseCase.invoke(
+            new ReviewCreateSimpleUseCase.Command(
                 request.perfumeId(),
                 request.score(),
                 request.content()
@@ -29,9 +34,19 @@ public class ReviewController implements ReviewApi {
     }
 
     @Override
+    public SuccessResponse<GetReviewDetailInfoResponse> getDetailInfo() {
+        Result result = evaluationCodeGetUseCase.invoke();
+
+        return SuccessResponse.of(new GetReviewDetailInfoResponse(
+            result.evaluationFieldDTOS(),
+            result.evaluationMoods()
+        ));
+    }
+
+    @Override
     public void update(
         Long reviewId,
-        ReviewUpdateRequest request
+        UpdateReviewSimpleRequest request
     ) {
         reviewUpdateUseCase.invoke(
             new ReviewUpdateUseCase.Command(

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/CreateReviewSimpleRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/CreateReviewSimpleRequest.java
@@ -3,8 +3,8 @@ package com.pikachu.purple.bootstrap.review.dto.request;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
-public record ReviewUpdateRequest (
-    Long ratingId,
+public record CreateReviewSimpleRequest(
+    Long perfumeId,
     @Range(min = 1, max = 5)
     int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/UpdateReviewSimpleRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/request/UpdateReviewSimpleRequest.java
@@ -3,8 +3,8 @@ package com.pikachu.purple.bootstrap.review.dto.request;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
-public record ReviewCreateRequest(
-    Long perfumeId,
+public record UpdateReviewSimpleRequest(
+    Long ratingId,
     @Range(min = 1, max = 5)
     int score,
     @Size(min = 10, max = 300, message = "최소 10자 ~ 최대 300자 입력할 수 있습니다.")

--- a/src/main/java/com/pikachu/purple/bootstrap/review/dto/response/GetReviewDetailInfoResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/dto/response/GetReviewDetailInfoResponse.java
@@ -1,0 +1,12 @@
+package com.pikachu.purple.bootstrap.review.dto.response;
+
+import com.pikachu.purple.application.evaluation.common.dto.EvaluationFieldDTO;
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import java.util.List;
+
+public record GetReviewDetailInfoResponse(
+    List<EvaluationFieldDTO> evaluationFieldDTOs,
+    List<EvaluationMood> moods
+) {
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationCode.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationCode.java
@@ -1,0 +1,28 @@
+package com.pikachu.purple.domain.evaluation;
+
+import com.pikachu.purple.domain.evaluation.enums.EvaluationCodeType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationCode {
+
+    private String code;
+    private String name;
+    private EvaluationCodeType type;
+
+    @Builder
+    public EvaluationCode(
+        String code,
+        String name,
+        EvaluationCodeType type
+    ) {
+        this.code = code;
+        this.name = name;
+        this.type = type;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationFieldOption.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationFieldOption.java
@@ -1,0 +1,27 @@
+package com.pikachu.purple.domain.evaluation;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationFieldOption {
+
+    private Long evaluationFieldOptionId;
+    private String fieldCode;
+    private String optionCode;
+
+    @Builder
+    public EvaluationFieldOption(
+        Long evaluationFieldOptionId,
+        String fieldCode,
+        String optionCode
+    ) {
+        this.evaluationFieldOptionId = evaluationFieldOptionId;
+        this.fieldCode = fieldCode;
+        this.optionCode = optionCode;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationMood.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/EvaluationMood.java
@@ -1,0 +1,19 @@
+package com.pikachu.purple.domain.evaluation;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationMood {
+
+    private String moodName;
+
+    @Builder
+    public EvaluationMood(String moodName) {
+        this.moodName = moodName;
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationCodeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationCodeJpaAdaptor.java
@@ -1,0 +1,27 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.adaptor;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationCodeRepository;
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationCodeJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.evaluation.repository.EvaluationCodeJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EvaluationCodeJpaAdaptor implements EvaluationCodeRepository {
+
+    private final EvaluationCodeJpaRepository evaluationCodeJpaRepository;
+
+    @Override
+    public List<EvaluationCode> findAll() {
+        List<EvaluationCodeJpaEntity> evaluationCodeJpaEntities = evaluationCodeJpaRepository.findAll();
+
+        return evaluationCodeJpaEntities.stream()
+            .map(EvaluationCodeJpaEntity::toDomain)
+            .toList();
+    }
+
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationFieldOptionJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationFieldOptionJpaAdaptor.java
@@ -1,0 +1,26 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.adaptor;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationFieldOptionRepository;
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationFieldOptionJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.evaluation.repository.EvaluationFieldOptionJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EvaluationFieldOptionJpaAdaptor implements EvaluationFieldOptionRepository {
+
+    private final EvaluationFieldOptionJpaRepository evaluationFieldOptionJpaRepository;
+
+    @Override
+    public List<EvaluationFieldOption> findAll() {
+        List<EvaluationFieldOptionJpaEntity> evaluationFieldOptionJpaEntities = evaluationFieldOptionJpaRepository.findAll();
+
+        return evaluationFieldOptionJpaEntities.stream()
+            .map(EvaluationFieldOptionJpaEntity::toDomain)
+            .toList();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationMoodJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/EvaluationMoodJpaAdaptor.java
@@ -1,0 +1,26 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.adaptor;
+
+import com.pikachu.purple.application.evaluation.port.out.EvaluationMoodRepository;
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationMoodJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.evaluation.repository.EvaluationMoodJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EvaluationMoodJpaAdaptor implements EvaluationMoodRepository {
+
+    private final EvaluationMoodJpaRepository evaluationMoodJpaRepository;
+
+    @Override
+    public List<EvaluationMood> findAll() {
+        List<EvaluationMoodJpaEntity> evaluationMoodJpaEntities = evaluationMoodJpaRepository.findAll();
+
+        return evaluationMoodJpaEntities.stream()
+            .map(EvaluationMoodJpaEntity::toDomain)
+            .toList();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationCodeJpaEntity.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
 
+import com.pikachu.purple.domain.evaluation.EvaluationCode;
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
 import com.pikachu.purple.domain.evaluation.enums.EvaluationCodeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -27,5 +29,13 @@ public class EvaluationCodeJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "type", columnDefinition = "varchar(255)", nullable = false)
     private EvaluationCodeType type;
+
+    public static EvaluationCode toDomain(EvaluationCodeJpaEntity evaluationCodeJpaEntity) {
+        return EvaluationCode.builder()
+            .code(evaluationCodeJpaEntity.getCode())
+            .name(evaluationCodeJpaEntity.getName())
+            .type(evaluationCodeJpaEntity.getType())
+            .build();
+    }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationFieldOptionJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationFieldOptionJpaEntity.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
 
+import com.pikachu.purple.domain.evaluation.EvaluationFieldOption;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -32,5 +33,13 @@ public class EvaluationFieldOptionJpaEntity {
 
     @Column(name = "option_code", columnDefinition = "char(5)", nullable = false)
     private String optionCode;
+
+    public static EvaluationFieldOption toDomain(EvaluationFieldOptionJpaEntity evaluationFieldOptionJpaEntity) {
+        return EvaluationFieldOption.builder()
+            .evaluationFieldOptionId(evaluationFieldOptionJpaEntity.getEvaluationFieldOptionId())
+            .fieldCode(evaluationFieldOptionJpaEntity.getFieldCode())
+            .optionCode(evaluationFieldOptionJpaEntity.getOptionCode())
+            .build();
+    }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationMoodJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/EvaluationMoodJpaEntity.java
@@ -1,0 +1,28 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
+
+import com.pikachu.purple.domain.evaluation.EvaluationMood;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "evaluation_mood")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EvaluationMoodJpaEntity {
+
+    @Id
+    @Column(name = "mood_name")
+    private String moodName;
+
+    public static EvaluationMood toDomain(EvaluationMoodJpaEntity evaluationMoodJpaEntity) {
+        return EvaluationMood.builder()
+            .moodName(evaluationMoodJpaEntity.getMoodName())
+            .build();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationCodeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationCodeJpaRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.repository;
+
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationCodeJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EvaluationCodeJpaRepository extends JpaRepository<EvaluationCodeJpaEntity, String> {
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationFieldOptionJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationFieldOptionJpaRepository.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.repository;
+
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationFieldOptionJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EvaluationFieldOptionJpaRepository extends JpaRepository<EvaluationFieldOptionJpaEntity, Long> {
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationMoodJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/EvaluationMoodJpaRepository.java
@@ -1,0 +1,8 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.repository;
+
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.EvaluationMoodJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EvaluationMoodJpaRepository extends JpaRepository<EvaluationMoodJpaEntity, String> {
+
+}


### PR DESCRIPTION
### 진행상황
- 자세한 코멘트 평가 항목에 필요한 정보들을 조회합니다.
- 조회 시 json 형태는 아래와 같습니다.
- 엘라스틱 의존성 제거했습니다.
- 컨벤션에 맞게 클래스명을 변경했습니다.
- 간단한 코멘트와 자세한 코멘트를 구분하기 위해 URI 및 클래스 명을 변경했습니다.
  - (간단한 코멘트 : simple / 자세한 코멘트 : detail)

### 추후 PR
- 자세한 코멘트 api
- 코멘트 토픽 api
- fieldOption/code 테이블에서 Enum으로 변경

### json
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/feac7299-bc6b-4a47-9fa2-7c57b93d474f">
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/03a86122-c076-4558-b3c6-43930cd65d81">
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/78510d01-ff3b-4468-9c24-cad624ef107c">