### PR TITLE
[PURPLE-132] 프라그란티카 평가 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/FragranticaEvaluationDTO.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/FragranticaEvaluationDTO.java
@@ -3,17 +3,17 @@ package com.pikachu.purple.application.evaluation.common.dto;
 import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
 import java.util.List;
 
-public record FragranticaEvaluationDto(
+public record FragranticaEvaluationDTO(
     String fieldCode,
     String fieldName,
     List<MostVotedOption> mostVotedOptions
 ) {
 
-    public static FragranticaEvaluationDto of(
+    public static FragranticaEvaluationDTO of(
         EvaluationField evaluationField,
         List<MostVotedOption> mostVotedOptions
     ) {
-        return new FragranticaEvaluationDto(
+        return new FragranticaEvaluationDTO(
             evaluationField.getCode(),
             evaluationField.getName(),
             mostVotedOptions

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/FragranticaEvaluationDto.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/FragranticaEvaluationDto.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.evaluation.common.dto;
+
+import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
+import java.util.List;
+
+public record FragranticaEvaluationDto(
+    String fieldCode,
+    String fieldName,
+    List<MostVotedOption> mostVotedOptions
+) {
+
+    public static FragranticaEvaluationDto of(
+        EvaluationField evaluationField,
+        List<MostVotedOption> mostVotedOptions
+    ) {
+        return new FragranticaEvaluationDto(
+            evaluationField.getCode(),
+            evaluationField.getName(),
+            mostVotedOptions
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
@@ -16,7 +16,10 @@ public record MostVotedOption(
         return new MostVotedOption(
             fragranticaEvaluation.getOption().getCode(),
             fragranticaEvaluation.getOption().getName(),
-            MathUtil.getPercentage(fragranticaEvaluation.getVotes(), totalVotesByField)
+            MathUtil.getPercentage(
+                fragranticaEvaluation.getVotes(),
+                totalVotesByField
+            )
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
@@ -1,18 +1,22 @@
 package com.pikachu.purple.application.evaluation.common.dto;
 
+import com.pikachu.purple.application.util.MathUtil;
 import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
 
 public record MostVotedOption(
     String optionCode,
     String optionName,
-    int votes
+    int votePercent
 ) {
 
-    public static MostVotedOption from(FragranticaEvaluation fragranticaEvaluation) {
+    public static MostVotedOption of(
+        FragranticaEvaluation fragranticaEvaluation,
+        int totalVotesByField
+    ) {
         return new MostVotedOption(
             fragranticaEvaluation.getOption().getCode(),
             fragranticaEvaluation.getOption().getName(),
-            fragranticaEvaluation.getVotes()
+            MathUtil.getPercentage(fragranticaEvaluation.getVotes(), totalVotesByField)
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/common/dto/MostVotedOption.java
@@ -1,0 +1,19 @@
+package com.pikachu.purple.application.evaluation.common.dto;
+
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+
+public record MostVotedOption(
+    String optionCode,
+    String optionName,
+    int votes
+) {
+
+    public static MostVotedOption from(FragranticaEvaluation fragranticaEvaluation) {
+        return new MostVotedOption(
+            fragranticaEvaluation.getOption().getCode(),
+            fragranticaEvaluation.getOption().getName(),
+            fragranticaEvaluation.getVotes()
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/in/FragranticaEvaluationGetByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/in/FragranticaEvaluationGetByPerfumeIdUseCase.java
@@ -1,0 +1,20 @@
+package com.pikachu.purple.application.evaluation.port.in;
+
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
+import com.pikachu.purple.application.perfume.common.dto.PerfumeDetailDto;
+import java.util.List;
+
+public interface FragranticaEvaluationGetByPerfumeIdUseCase {
+
+    FragranticaEvaluationGetByPerfumeIdUseCase.Result invoke(
+        FragranticaEvaluationGetByPerfumeIdUseCase.Command command);
+
+    record Command(Long perfumeId) {
+
+    }
+
+    record Result(List<FragranticaEvaluationDto> fragranticaEvaluations) {
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/in/FragranticaEvaluationGetByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/in/FragranticaEvaluationGetByPerfumeIdUseCase.java
@@ -1,7 +1,6 @@
 package com.pikachu.purple.application.evaluation.port.in;
 
-import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
-import com.pikachu.purple.application.perfume.common.dto.PerfumeDetailDto;
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDTO;
 import java.util.List;
 
 public interface FragranticaEvaluationGetByPerfumeIdUseCase {
@@ -13,7 +12,7 @@ public interface FragranticaEvaluationGetByPerfumeIdUseCase {
 
     }
 
-    record Result(List<FragranticaEvaluationDto> fragranticaEvaluations) {
+    record Result(List<FragranticaEvaluationDTO> fragranticaEvaluations) {
 
     }
 

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/out/FragranticaEvaluationRepository.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/out/FragranticaEvaluationRepository.java
@@ -7,8 +7,7 @@ public interface FragranticaEvaluationRepository {
 
     List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
         Long perfumeId,
-        String fieldCode,
-        int maxSize
+        String fieldCode
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/evaluation/port/out/FragranticaEvaluationRepository.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/port/out/FragranticaEvaluationRepository.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.evaluation.port.out;
+
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import java.util.List;
+
+public interface FragranticaEvaluationRepository {
+
+    List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+        Long perfumeId,
+        String fieldCode,
+        int maxSize
+    );
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
@@ -1,0 +1,65 @@
+package com.pikachu.purple.application.evaluation.service.application;
+
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
+import com.pikachu.purple.application.evaluation.common.dto.MostVotedOption;
+import com.pikachu.purple.application.evaluation.port.in.FragranticaEvaluationGetByPerfumeIdUseCase;
+import com.pikachu.purple.application.evaluation.service.domain.FragranticaEvaluationDomainService;
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
+    FragranticaEvaluationGetByPerfumeIdUseCase {
+
+    private final FragranticaEvaluationDomainService fragranticaEvaluationDomainService;
+
+    @Override
+    public Result invoke(Command command) {
+        List<FragranticaEvaluationDto> fragranticaEvaluationDtos = new ArrayList<>();
+
+        for (EvaluationField evaluationField : EvaluationField.values()) {
+            if (evaluationField == EvaluationField.SEASON_TIME) {
+
+                FragranticaEvaluationDto fragranticaEvaluationDto = findResultByEachField(
+                    command.perfumeId(),
+                    evaluationField,
+                    3
+                );
+
+                fragranticaEvaluationDtos.add(fragranticaEvaluationDto);
+
+            } else {
+                FragranticaEvaluationDto fragranticaEvaluationDto = findResultByEachField(
+                    command.perfumeId(),
+                    evaluationField,
+                    1
+                );
+
+                fragranticaEvaluationDtos.add(fragranticaEvaluationDto);
+            }
+        }
+        return new Result(fragranticaEvaluationDtos);
+    }
+
+    private FragranticaEvaluationDto findResultByEachField(Long perfumeId, EvaluationField field, int maxSize) {
+        List<FragranticaEvaluation> fragranticaEvaluations =
+            fragranticaEvaluationDomainService.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+                perfumeId,
+                field.getCode(),
+                maxSize
+            );
+
+        List<MostVotedOption> mostVotedOptions =
+            fragranticaEvaluations.stream().map(MostVotedOption::from).toList();
+
+        return FragranticaEvaluationDto.of(
+            field,
+            mostVotedOptions
+        );
+    }
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
@@ -20,7 +20,7 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
 
     @Override
     public Result invoke(Command command) {
-        List<FragranticaEvaluationDTO> fragranticaEvaluationDTOS = new ArrayList<>();
+        List<FragranticaEvaluationDTO> fragranticaEvaluationDTOs = new ArrayList<>();
 
         for (EvaluationField evaluationField : EvaluationField.values()) {
             if (evaluationField == EvaluationField.SEASON_TIME) {
@@ -31,7 +31,7 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
                     3
                 );
 
-                fragranticaEvaluationDTOS.add(fragranticaEvaluationDTO);
+                fragranticaEvaluationDTOs.add(fragranticaEvaluationDTO);
 
             } else {
                 FragranticaEvaluationDTO fragranticaEvaluationDTO = findResultByEachField(
@@ -40,10 +40,10 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
                     1
                 );
 
-                fragranticaEvaluationDTOS.add(fragranticaEvaluationDTO);
+                fragranticaEvaluationDTOs.add(fragranticaEvaluationDTO);
             }
         }
-        return new Result(fragranticaEvaluationDTOS);
+        return new Result(fragranticaEvaluationDTOs);
     }
 
     private FragranticaEvaluationDTO findResultByEachField(Long perfumeId, EvaluationField field, int maxSize) {

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
@@ -4,11 +4,13 @@ import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluatio
 import com.pikachu.purple.application.evaluation.common.dto.MostVotedOption;
 import com.pikachu.purple.application.evaluation.port.in.FragranticaEvaluationGetByPerfumeIdUseCase;
 import com.pikachu.purple.application.evaluation.service.domain.FragranticaEvaluationDomainService;
+import com.pikachu.purple.application.util.MathUtil;
 import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
 import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,12 +52,21 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
         List<FragranticaEvaluation> fragranticaEvaluations =
             fragranticaEvaluationDomainService.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
                 perfumeId,
-                field.getCode(),
-                maxSize
+                field.getCode()
             );
 
-        List<MostVotedOption> mostVotedOptions =
-            fragranticaEvaluations.stream().map(MostVotedOption::from).toList();
+        int totalVotesByField = fragranticaEvaluations.stream()
+            .mapToInt(FragranticaEvaluation::getVotes).sum();
+
+        List<MostVotedOption> mostVotedOptions = new ArrayList<>();
+        for (int i=0; i < maxSize; i++) {
+            mostVotedOptions.add(
+                MostVotedOption.of(
+                    fragranticaEvaluations.get(i),
+                    totalVotesByField
+                )
+            );
+        }
 
         return FragranticaEvaluationDTO.of(
             field,

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/application/FragranticaEvaluationGetByPerfumeIdApplicationService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.evaluation.service.application;
 
-import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDTO;
 import com.pikachu.purple.application.evaluation.common.dto.MostVotedOption;
 import com.pikachu.purple.application.evaluation.port.in.FragranticaEvaluationGetByPerfumeIdUseCase;
 import com.pikachu.purple.application.evaluation.service.domain.FragranticaEvaluationDomainService;
@@ -20,33 +20,33 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
 
     @Override
     public Result invoke(Command command) {
-        List<FragranticaEvaluationDto> fragranticaEvaluationDtos = new ArrayList<>();
+        List<FragranticaEvaluationDTO> fragranticaEvaluationDTOS = new ArrayList<>();
 
         for (EvaluationField evaluationField : EvaluationField.values()) {
             if (evaluationField == EvaluationField.SEASON_TIME) {
 
-                FragranticaEvaluationDto fragranticaEvaluationDto = findResultByEachField(
+                FragranticaEvaluationDTO fragranticaEvaluationDTO = findResultByEachField(
                     command.perfumeId(),
                     evaluationField,
                     3
                 );
 
-                fragranticaEvaluationDtos.add(fragranticaEvaluationDto);
+                fragranticaEvaluationDTOS.add(fragranticaEvaluationDTO);
 
             } else {
-                FragranticaEvaluationDto fragranticaEvaluationDto = findResultByEachField(
+                FragranticaEvaluationDTO fragranticaEvaluationDTO = findResultByEachField(
                     command.perfumeId(),
                     evaluationField,
                     1
                 );
 
-                fragranticaEvaluationDtos.add(fragranticaEvaluationDto);
+                fragranticaEvaluationDTOS.add(fragranticaEvaluationDTO);
             }
         }
-        return new Result(fragranticaEvaluationDtos);
+        return new Result(fragranticaEvaluationDTOS);
     }
 
-    private FragranticaEvaluationDto findResultByEachField(Long perfumeId, EvaluationField field, int maxSize) {
+    private FragranticaEvaluationDTO findResultByEachField(Long perfumeId, EvaluationField field, int maxSize) {
         List<FragranticaEvaluation> fragranticaEvaluations =
             fragranticaEvaluationDomainService.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
                 perfumeId,
@@ -57,7 +57,7 @@ public class FragranticaEvaluationGetByPerfumeIdApplicationService implements
         List<MostVotedOption> mostVotedOptions =
             fragranticaEvaluations.stream().map(MostVotedOption::from).toList();
 
-        return FragranticaEvaluationDto.of(
+        return FragranticaEvaluationDTO.of(
             field,
             mostVotedOptions
         );

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/FragranticaEvaluationDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/FragranticaEvaluationDomainService.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.evaluation.service.domain;
+
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import java.util.List;
+
+public interface FragranticaEvaluationDomainService {
+
+    List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+        Long perfumeId,
+        String fieldCode,
+        int maxSize
+    );
+
+}

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/FragranticaEvaluationDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/FragranticaEvaluationDomainService.java
@@ -7,8 +7,7 @@ public interface FragranticaEvaluationDomainService {
 
     List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
         Long perfumeId,
-        String fieldCode,
-        int maxSize
+        String fieldCode
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/FragranticaEvaluationDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/FragranticaEvaluationDomainServiceImpl.java
@@ -16,13 +16,11 @@ public class FragranticaEvaluationDomainServiceImpl implements FragranticaEvalua
     @Override
     public List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
         Long perfumeId,
-        String fieldCode,
-        int maxSize
+        String fieldCode
     ) {
         return fragranticaEvaluationRepository.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
             perfumeId,
-            fieldCode,
-            maxSize
+            fieldCode
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/FragranticaEvaluationDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/evaluation/service/domain/impl/FragranticaEvaluationDomainServiceImpl.java
@@ -1,0 +1,29 @@
+package com.pikachu.purple.application.evaluation.service.domain.impl;
+
+import com.pikachu.purple.application.evaluation.port.out.FragranticaEvaluationRepository;
+import com.pikachu.purple.application.evaluation.service.domain.FragranticaEvaluationDomainService;
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FragranticaEvaluationDomainServiceImpl implements FragranticaEvaluationDomainService {
+
+    private final FragranticaEvaluationRepository fragranticaEvaluationRepository;
+
+    @Override
+    public List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+        Long perfumeId,
+        String fieldCode,
+        int maxSize
+    ) {
+        return fragranticaEvaluationRepository.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+            perfumeId,
+            fieldCode,
+            maxSize
+        );
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/util/MathUtil.java
+++ b/src/main/java/com/pikachu/purple/application/util/MathUtil.java
@@ -1,0 +1,9 @@
+package com.pikachu.purple.application.util;
+
+public class MathUtil {
+
+    public static int getPercentage(int part, int whole) {
+        return (int) Math.round(((double) part / (double) whole) * 100);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/util/MathUtil.java
+++ b/src/main/java/com/pikachu/purple/application/util/MathUtil.java
@@ -1,5 +1,8 @@
 package com.pikachu.purple.application.util;
 
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
 public class MathUtil {
 
     public static int getPercentage(int part, int whole) {

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/api/PerfumeApi.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.bootstrap.perfume.api;
 
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.common.security.Secured;
+import com.pikachu.purple.bootstrap.perfume.dto.response.GetFragranticaEvaluationsResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByBrandsResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByKeywordResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeDetailResponse;
@@ -46,6 +47,13 @@ public interface PerfumeApi {
     @GetMapping("/{perfume-id}/detail")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<GetPerfumeDetailResponse> findPerfumeDetailByPerfumeId(
+        @PathVariable("perfume-id") Long perfumeId);
+
+    @Secured
+    @Operation(summary = "프라그란티카 평가 정보 조회")
+    @GetMapping("/{perfume-id}/fragrantica-evaluation")
+    @ResponseStatus(HttpStatus.OK)
+    SuccessResponse<GetFragranticaEvaluationsResponse> findFragranticaEvaluationsByPerfumeId(
         @PathVariable("perfume-id") Long perfumeId);
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.bootstrap.perfume.controller;
 
+import com.pikachu.purple.application.evaluation.port.in.FragranticaEvaluationGetByPerfumeIdUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeDetailGetByPerfumeIdUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByBrandsUseCase;
 import com.pikachu.purple.application.perfume.port.in.PerfumeGetByKeywordUseCase;
@@ -7,6 +8,7 @@ import com.pikachu.purple.application.perfume.port.in.PerfumeGetByUserPreference
 import com.pikachu.purple.application.user.port.in.UserSaveSearchHistoryUseCase;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.perfume.api.PerfumeApi;
+import com.pikachu.purple.bootstrap.perfume.dto.response.GetFragranticaEvaluationsResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByBrandsResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeByKeywordResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeDetailResponse;
@@ -24,6 +26,7 @@ public class PerfumeController implements PerfumeApi {
     private final PerfumeGetByUserPreferenceNoteUseCase perfumeGetByUserPreferenceNoteUseCase;
     private final PerfumeGetByKeywordUseCase perfumeGetByKeywordUseCase;
     private final PerfumeDetailGetByPerfumeIdUseCase perfumeDetailGetByPerfumeIdUseCase;
+    private final FragranticaEvaluationGetByPerfumeIdUseCase fragranticaEvaluationGetByPerfumeIdUseCase;
     private final UserSaveSearchHistoryUseCase userSaveSearchHistoryUseCase;
 
     @Override
@@ -66,6 +69,16 @@ public class PerfumeController implements PerfumeApi {
         // TODO: userSaveVisitedHistoryUseCase 구현
 
         return SuccessResponse.of(new GetPerfumeDetailResponse(result.perfumeDetail()));
+    }
+
+    @Override
+    public SuccessResponse<GetFragranticaEvaluationsResponse> findFragranticaEvaluationsByPerfumeId(
+        Long perfumeId) {
+
+        FragranticaEvaluationGetByPerfumeIdUseCase.Result result = fragranticaEvaluationGetByPerfumeIdUseCase.invoke(
+            new FragranticaEvaluationGetByPerfumeIdUseCase.Command(perfumeId));
+
+        return SuccessResponse.of(new GetFragranticaEvaluationsResponse(result.fragranticaEvaluations()));
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetFragranticaEvaluationsResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetFragranticaEvaluationsResponse.java
@@ -1,10 +1,10 @@
 package com.pikachu.purple.bootstrap.perfume.dto.response;
 
-import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDTO;
 import java.util.List;
 
 public record GetFragranticaEvaluationsResponse(
-    List<FragranticaEvaluationDto> fragranticaEvaluations
+    List<FragranticaEvaluationDTO> fragranticaEvaluations
 ) {
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetFragranticaEvaluationsResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/dto/response/GetFragranticaEvaluationsResponse.java
@@ -1,0 +1,10 @@
+package com.pikachu.purple.bootstrap.perfume.dto.response;
+
+import com.pikachu.purple.application.evaluation.common.dto.FragranticaEvaluationDto;
+import java.util.List;
+
+public record GetFragranticaEvaluationsResponse(
+    List<FragranticaEvaluationDto> fragranticaEvaluations
+) {
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/FragranticaEvaluation.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.domain.evaluation;
 
+import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
+import com.pikachu.purple.domain.evaluation.enums.EvaluationOption;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,28 +13,22 @@ public class FragranticaEvaluation {
 
     private Long fragranticaEvaluationId;
     private Long perfumeId;
-    private String fieldCode;
-    private String fieldName;
-    private String optionCode;
-    private String optionName;
+    private EvaluationField field;
+    private EvaluationOption option;
     private int votes;
 
     @Builder
     public FragranticaEvaluation(
             Long fragranticaEvaluationId,
             Long perfumeId,
-            String fieldCode,
-            String fieldName,
-            String optionCode,
-            String optionName,
-            Integer votes
+            EvaluationField field,
+            EvaluationOption option,
+            int votes
     ) {
         this.fragranticaEvaluationId = fragranticaEvaluationId;
         this.perfumeId = perfumeId;
-        this.fieldCode = fieldCode;
-        this.fieldName = fieldName;
-        this.optionCode = optionCode;
-        this.optionName = optionName;
+        this.field = field;
+        this.option = option;
         this.votes = votes;
     }
 

--- a/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationField.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationField.java
@@ -1,0 +1,73 @@
+package com.pikachu.purple.domain.evaluation.enums;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EvaluationField {
+    LONGEVITY(
+        "EF001",
+        "지속력",
+        Arrays.asList(
+            EvaluationOption.LONGEVITY_VERY_WEEK,
+            EvaluationOption.LONGEVITY_WEEK,
+            EvaluationOption.LONGEVITY_MODERATE,
+            EvaluationOption.LONGEVITY_LONG_LASTING,
+            EvaluationOption.LONGEVITY_ETERNAL
+        )
+    ),
+    SILLAGE(
+        "EF002",
+        "시야주",
+        Arrays.asList(
+            EvaluationOption.SILLAGE_INTIMATE,
+            EvaluationOption.SILLAGE_MODERATE,
+            EvaluationOption.SILLAGE_STRONG,
+            EvaluationOption.SILLAGE_ENORMOUS
+        )
+    ),
+    SEASON_TIME(
+        "EF003",
+        "계절감/시간",
+        Arrays.asList(
+            EvaluationOption.SEASON_TIME_SPRING,
+            EvaluationOption.SEASON_TIME_SUMMER,
+            EvaluationOption.SEASON_TIME_FALL,
+            EvaluationOption.SEASON_TIME_WINTER,
+            EvaluationOption.SEASON_TIME_DAY,
+            EvaluationOption.SEASON_TIME_NIGHT
+        )
+    ),
+    GENDER(
+        "EF004",
+        "성별",
+        Arrays.asList(
+            EvaluationOption.GENDER_MALE,
+            EvaluationOption.GENDER_MORE_MALE,
+            EvaluationOption.GENDER_UNISEX,
+            EvaluationOption.GENDER_MORE_FEMALE,
+            EvaluationOption.GENDER_FEMALE
+        )
+    );
+
+    private final String code;
+    private final String name;
+    private final List<EvaluationOption> evaluationOptions;
+
+    private final static Map<String, String> CODE_MAP = Collections.unmodifiableMap(
+        Stream.of(values())
+            .collect(Collectors.toMap(EvaluationField::getCode, EvaluationField::name))
+    );
+
+    public static EvaluationField of(String code) {
+        return EvaluationField.valueOf(CODE_MAP.get(code));
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationField.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationField.java
@@ -61,7 +61,7 @@ public enum EvaluationField {
     private final String name;
     private final List<EvaluationOption> evaluationOptions;
 
-    private final static Map<String, String> CODE_MAP = Collections.unmodifiableMap(
+    private static final Map<String, String> CODE_MAP = Collections.unmodifiableMap(
         Stream.of(values())
             .collect(Collectors.toMap(EvaluationField::getCode, EvaluationField::name))
     );

--- a/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationOption.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationOption.java
@@ -1,0 +1,50 @@
+package com.pikachu.purple.domain.evaluation.enums;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EvaluationOption {
+
+    LONGEVITY_VERY_WEEK("EO101", "매우 약함"),
+    LONGEVITY_WEEK("EO102", "약함"),
+    LONGEVITY_MODERATE("EO103", "보통"),
+    LONGEVITY_LONG_LASTING("EO104", "오래감"),
+    LONGEVITY_ETERNAL("EO105", "매우 오래감"),
+
+    SILLAGE_INTIMATE("EO201", "향 여운이 약함"),
+    SILLAGE_MODERATE("EO202", "보통"),
+    SILLAGE_STRONG("EO203", "향 여운이 강함"),
+    SILLAGE_ENORMOUS("EO204", "향 여운이 매우 강함"),
+
+    SEASON_TIME_SPRING("EO301", "봄"),
+    SEASON_TIME_SUMMER("EO302", "여름"),
+    SEASON_TIME_FALL("EO303", "가을"),
+    SEASON_TIME_WINTER("EO304", "겨울"),
+    SEASON_TIME_DAY("EO305", "낮"),
+    SEASON_TIME_NIGHT("EO306", "밤"),
+
+    GENDER_MALE("EO401", "남성"),
+    GENDER_MORE_MALE("EO402", "남성에 가까운"),
+    GENDER_UNISEX("EO403", "중성"),
+    GENDER_MORE_FEMALE("EO404", "여성에 가까운"),
+    GENDER_FEMALE("EO405", "여성");
+
+    private final String code;
+    private final String name;
+
+    private final static Map<String, String> CODE_MAP = Collections.unmodifiableMap(
+        Stream.of(values())
+            .collect(Collectors.toMap(EvaluationOption::getCode, EvaluationOption::name))
+    );
+
+    public static EvaluationOption of(String code) {
+        return EvaluationOption.valueOf(CODE_MAP.get(code));
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationOption.java
+++ b/src/main/java/com/pikachu/purple/domain/evaluation/enums/EvaluationOption.java
@@ -38,7 +38,7 @@ public enum EvaluationOption {
     private final String code;
     private final String name;
 
-    private final static Map<String, String> CODE_MAP = Collections.unmodifiableMap(
+    private static final Map<String, String> CODE_MAP = Collections.unmodifiableMap(
         Stream.of(values())
             .collect(Collectors.toMap(EvaluationOption::getCode, EvaluationOption::name))
     );

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
@@ -1,0 +1,37 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.adaptor;
+
+import com.pikachu.purple.application.evaluation.port.out.FragranticaEvaluationRepository;
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.FragranticaEvaluationJpaEntity;
+import com.pikachu.purple.infrastructure.persistence.evaluation.repository.FragranticaEvaluationJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Limit;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FragranticaEvaluationJpaAdaptor implements FragranticaEvaluationRepository {
+
+    private final FragranticaEvaluationJpaRepository fragranticaEvaluationJpaRepository;
+
+    @Override
+    public List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+        Long perfumeId,
+        String fieldCode,
+        int maxSize
+    ) {
+        List<FragranticaEvaluationJpaEntity> fragranticaEvaluationJpaEntities = fragranticaEvaluationJpaRepository.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+            perfumeId,
+            fieldCode,
+            Limit.of(maxSize)
+        );
+
+        return fragranticaEvaluationJpaEntities.stream()
+            .map(FragranticaEvaluationJpaEntity::toDomain).toList();
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
@@ -6,7 +6,6 @@ import com.pikachu.purple.infrastructure.persistence.evaluation.entity.Fragranti
 import com.pikachu.purple.infrastructure.persistence.evaluation.repository.FragranticaEvaluationJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
@@ -6,12 +6,10 @@ import com.pikachu.purple.infrastructure.persistence.evaluation.entity.Fragranti
 import com.pikachu.purple.infrastructure.persistence.evaluation.repository.FragranticaEvaluationJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FragranticaEvaluationJpaAdaptor implements FragranticaEvaluationRepository {

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/adaptor/FragranticaEvaluationJpaAdaptor.java
@@ -19,13 +19,11 @@ public class FragranticaEvaluationJpaAdaptor implements FragranticaEvaluationRep
     @Override
     public List<FragranticaEvaluation> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
         Long perfumeId,
-        String fieldCode,
-        int maxSize
+        String fieldCode
     ) {
         List<FragranticaEvaluationJpaEntity> fragranticaEvaluationJpaEntities = fragranticaEvaluationJpaRepository.findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
             perfumeId,
-            fieldCode,
-            Limit.of(maxSize)
+            fieldCode
         );
 
         return fragranticaEvaluationJpaEntities.stream()

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/entity/FragranticaEvaluationJpaEntity.java
@@ -1,5 +1,10 @@
 package com.pikachu.purple.infrastructure.persistence.evaluation.entity;
 
+import com.pikachu.purple.domain.evaluation.FragranticaEvaluation;
+import com.pikachu.purple.domain.evaluation.enums.EvaluationField;
+import com.pikachu.purple.domain.evaluation.enums.EvaluationOption;
+import com.pikachu.purple.domain.perfume.Perfume;
+import com.pikachu.purple.infrastructure.persistence.perfume.entity.PerfumeJpaEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -29,5 +34,16 @@ public class FragranticaEvaluationJpaEntity {
 
     @Column(name = "votes", nullable = false)
     private int votes;
+
+    public static FragranticaEvaluation toDomain(FragranticaEvaluationJpaEntity jpaEntity) {
+
+        return FragranticaEvaluation.builder()
+            .fragranticaEvaluationId(jpaEntity.getFragranticaEvaluationId())
+            .perfumeId(jpaEntity.getPerfumeId())
+            .field(EvaluationField.of(jpaEntity.getFieldCode()))
+            .option(EvaluationOption.of(jpaEntity.getOptionCode()))
+            .votes(jpaEntity.getVotes())
+            .build();
+    }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
@@ -10,8 +10,7 @@ public interface FragranticaEvaluationJpaRepository extends
 
   List<FragranticaEvaluationJpaEntity> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
       Long perfumeId,
-      String fieldCode,
-      Limit limit
+      String fieldCode
   );
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
@@ -2,7 +2,6 @@ package com.pikachu.purple.infrastructure.persistence.evaluation.repository;
 
 import com.pikachu.purple.infrastructure.persistence.evaluation.entity.FragranticaEvaluationJpaEntity;
 import java.util.List;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FragranticaEvaluationJpaRepository extends

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/evaluation/repository/FragranticaEvaluationJpaRepository.java
@@ -1,0 +1,17 @@
+package com.pikachu.purple.infrastructure.persistence.evaluation.repository;
+
+import com.pikachu.purple.infrastructure.persistence.evaluation.entity.FragranticaEvaluationJpaEntity;
+import java.util.List;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FragranticaEvaluationJpaRepository extends
+    JpaRepository<FragranticaEvaluationJpaEntity, Long> {
+
+  List<FragranticaEvaluationJpaEntity> findAllByPerfumeIdAndFieldCodeOrderByVotesDesc(
+      Long perfumeId,
+      String fieldCode,
+      Limit limit
+  );
+
+}

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeBrandJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeBrandJpaAdaptor.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PerfumeBrandJpaAdaptor implements PerfumeBrandRepository {
 
-    private final static int MAX_SIZE = 30;
+    private static final int MAX_SIZE = 30;
     private final PerfumeBrandJpaRepository perfumeBrandJpaRepository;
 
     @Override

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PerfumeJpaAdaptor implements PerfumeRepository {
 
-    private final static int MAX_SIZE = 30;
+    private static final int MAX_SIZE = 30;
     private final PerfumeJpaRepository perfumeJpaRepository;
 
     public List<Perfume> findByPerfumeBrands(List<String> brands) {


### PR DESCRIPTION
## 진행상황
- 프라그란티카 평가 정보 조회 API 구현
  - 프라그란티카 평가영역별 최다 득표 결과 조회
- EvaluationField, EvaluationOption enum 정의

### API 명세
- 응답 정보
<img width="465" alt="image" src="https://github.com/user-attachments/assets/437543a4-425f-4ffa-93fe-9527138a69f1">

<details>
<summary>결과 샘플</summary>
<div markdown="2">

```json
{
  "timeStamp": "2024-09-05T18:40:43.0223",
  "responseData": {
    "fragranticaEvaluations": [
      {
        "fieldCode": "EF001",
        "fieldName": "지속력",
        "mostVotedOptions": [
          {
            "optionCode": "EO103",
            "optionName": "보통",
            "votePercent": 57
          }
        ]
      },
      {
        "fieldCode": "EF002",
        "fieldName": "시야주",
        "mostVotedOptions": [
          {
            "optionCode": "EO202",
            "optionName": "보통",
            "votePercent": 63
          }
        ]
      },
      {
        "fieldCode": "EF003",
        "fieldName": "계절감/시간",
        "mostVotedOptions": [
          {
            "optionCode": "EO301",
            "optionName": "봄",
            "votePercent": 30
          },
          {
            "optionCode": "EO305",
            "optionName": "낮",
            "votePercent": 27
          },
          {
            "optionCode": "EO302",
            "optionName": "여름",
            "votePercent": 23
          }
        ]
      },
      {
        "fieldCode": "EF004",
        "fieldName": "성별",
        "mostVotedOptions": [
          {
            "optionCode": "EO405",
            "optionName": "여성",
            "votePercent": 73
          }
        ]
      }
    ]
  }
}
```

</div>
</details>


## 추후 PR
- EvaluationCode, EvaluationFieldOption 관련 도메인 및 테이블 제거