### PR TITLE
[PURPLE-156] docker volume 설정 및 redis 비밀번호 추가

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -3,7 +3,9 @@ services:
   spring:
     image: public.ecr.aws/${ECR_REGISTRY_ALIAS}/purple-ecr:${VERSION:-latest}
     volumes:
-      - mysql-volume:/var/lib/mysql
+      - type: bind
+        source: ${MYSQL_MOUNT_PATH}
+        target: /var/lib/mysql
     environment:
       - VERSION=${VERSION:-latest}
       - SPRING_PROFILES_ACTIVE=dev
@@ -13,21 +15,31 @@ services:
     depends_on:
       - mysql
     ports:
-      - "8080:8080"
+      - "${SPRING_DEV_PORT}:8080"
   mysql:
     image: mysql:8.0.33
+    volumes:
+      - type: bind
+        source: ${MYSQL_MOUNT_PATH}
+        target: /var/lib/mysql
     environment:
       MYSQL_DATABASE: purple
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       TZ: Asia/Seoul
     ports:
-      - "3306:3306"
+      - "${MYSQL_DEV_PORT}:3306"
 
   redis:
     image: redis:7.2.4
+    volumes:
+      - type: bind
+        source: ${REDIS_MOUNT_PATH}
+        target: /data
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    command: [ "redis-server", "--requirepass", "${REDIS_PASSWORD}" ]
     container_name: redis_dev
-    ports:
-      - "6379:6379"
 
 volumes:
   mysql-volume:
+  redis-volume:

--- a/compose-local.yaml
+++ b/compose-local.yaml
@@ -19,3 +19,6 @@ services:
     image: redis:7.2.4
     ports:
       - "6379:6379"
+    environment:
+      REDIS_PASSWORD: secret
+    command: [ "redis-server", "--requirepass", "secret" ]

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/common/RedisConfig.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/common/RedisConfig.java
@@ -27,6 +27,9 @@ public class RedisConfig {
     @Value(value = "${spring.data.redis.port}")
     private int port;
 
+    @Value(value = "${spring.data.redis.password}")
+    private String password;
+
     private static final String REDISSON_HOST_PREFIX = "redis://";
 
     @Bean
@@ -37,7 +40,7 @@ public class RedisConfig {
                 + host
                 + ":"
                 + port
-        );
+        ).setPassword(password);
 
         return Redisson.create(config);
     }


### PR DESCRIPTION
### 진행상황
- 데이터베이스 현상관리를 위해 volume을 설정했습니다.

![image](https://github.com/user-attachments/assets/2386cf51-0b81-4412-8a80-d8bf9f75ddeb)
- api 연동 작업 중 refresh token 만료 주기 대비 빠르게 만료되어, 확인해본 결과 redis 내부 해킹 목적의 스크립트가 적용되어 있었습니다.
- redis 내 비밀번호 설정하여 선 조치했습니다.