### PR TITLE
[PURPLE-171] 향수 리뷰 조회 api 응답정보에 isCurrentUserReview 추가

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewDTO.java
+++ b/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewDTO.java
@@ -16,12 +16,14 @@ public record ReviewDTO(
     String content,
     List<ReviewEvaluationFieldDTO> perfumeEvaluation,
     List<String> moodNames,
+    boolean isCurrentUserReview,
     boolean isComplained,
     boolean isLiked,
     int likeCount
 ) {
 
     public static ReviewDTO of(
+        Long currentUserId,
         Review review,
         List<ReviewEvaluationFieldDTO> perfumeEvaluation,
         List<String> moodNames
@@ -36,7 +38,8 @@ public record ReviewDTO(
             review.getContent(),
             perfumeEvaluation,
             moodNames,
-            false, //TODO
+            currentUserId.equals(review.getUser().getId()),
+            review.isComplained(),
             false, //TODO
             review.getLikeCount()
         );

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsByPerfumeIdAndSortTypeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsByPerfumeIdAndSortTypeApplicationService.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.application.review.service.application.review;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.review.common.dto.ReviewDTO;
 import com.pikachu.purple.application.review.common.dto.ReviewEvaluationFieldDTO;
 import com.pikachu.purple.application.review.common.dto.ReviewEvaluationOptionDTO;
@@ -24,6 +26,7 @@ public class GetReviewsByPerfumeIdAndSortTypeApplicationService implements
     @Transactional
     @Override
     public Result invoke(Command command) {
+        Long userId = getCurrentUserAuthentication().userId();
         SortType sortType = SortType.transByStr(command.sortType());
 
         List<Review> reviews = new ArrayList<>();
@@ -65,6 +68,7 @@ public class GetReviewsByPerfumeIdAndSortTypeApplicationService implements
                     .toList();
 
                 return ReviewDTO.of(
+                    userId,
                     review,
                     reviewEvaluation,
                     moodNames


### PR DESCRIPTION
## 진행 사항
- 향수 리뷰 조회 api 응답정보에 isCurrentUserReview 추가

### /perpicks/perfumes/{perfume-id}/reviews
<img width="622" alt="스크린샷 2024-10-14 오후 8 08 19" src="https://github.com/user-attachments/assets/5eaf8236-027c-48de-844f-14e32e25a6ce">
