### PR TITLE
[PURPLE-165] 선호/불호 노트를 위한 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/out/PerfumeRepository.java
@@ -12,7 +12,7 @@ public interface PerfumeRepository {
 
     List<Perfume> findAllByBrandNames(List<String> brandNames);
 
-    List<Perfume> findAllWithPerfumeAccordsByAccords(List<Accord> accords);
+    List<Perfume> findAllWithPerfumeAccordsByAccords(List<Accord> accords, int maxSize);
 
     List<Perfume> findAllHavingReviewCountNotZeroOrderByReviewCount(int maxSize);
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -7,7 +7,7 @@ import com.pikachu.purple.application.perfume.common.dto.UserAccordDTO;
 import com.pikachu.purple.application.perfume.common.vo.PerfumeAccordMatchVO;
 import com.pikachu.purple.application.perfume.port.in.GetPerfumesAndUserAccordsByUserUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
-import com.pikachu.purple.application.user.port.in.useraccord.GetUserAccordsUseCase;
+import com.pikachu.purple.application.user.port.in.useraccord.GetTopThreeUserAccordsUseCase;
 import com.pikachu.purple.domain.accord.Accord;
 import com.pikachu.purple.domain.perfume.Perfume;
 import java.util.ArrayList;
@@ -23,12 +23,13 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
     GetPerfumesAndUserAccordsByUserUseCase {
 
     private final PerfumeDomainService perfumeDomainService;
-    private final GetUserAccordsUseCase getUserAccordsUseCase;
+    private final GetTopThreeUserAccordsUseCase getTopThreeUserAccordsUseCase;
+    private final static int MAX_SIZE = 30;
 
     @Transactional
     @Override
     public Result invoke() {
-        GetUserAccordsUseCase.Result result = getUserAccordsUseCase.invoke();
+        GetTopThreeUserAccordsUseCase.Result result = getTopThreeUserAccordsUseCase.invoke();
 
         if (result.userAccords().isEmpty()) {
             throw UserAccordNotFoundException;
@@ -50,11 +51,9 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
 
         List<Accord> accords = new ArrayList<>(result.userAccords());
         List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByAccords(
-            accords.stream()
-                .filter(accord -> topThreeUserAccordNames.contains(accord.getName()))
-                .toList()
+            accords,
+            MAX_SIZE
         );
-
 
         List<RecommendedPerfumeDTO> recommendedPerfumeDTOs = perfumes.stream()
             .map(perfume -> {

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -24,7 +24,7 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
 
     private final PerfumeDomainService perfumeDomainService;
     private final GetTopThreeUserAccordsUseCase getTopThreeUserAccordsUseCase;
-    private final static int MAX_SIZE = 30;
+    private static final int MAX_SIZE = 30;
 
     @Transactional
     @Override

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/PerfumeDomainService.java
@@ -12,7 +12,10 @@ public interface PerfumeDomainService {
 
     List<Perfume> findAllByBrandNames(List<String> brandNames);
 
-    List<Perfume> findAllWithPerfumeAccordsByAccords(List<Accord> accords);
+    List<Perfume> findAllWithPerfumeAccordsByAccords(
+        List<Accord> accords,
+        int maxSize
+    );
 
     List<Perfume> findAllOrderByReviewCount(int maxSize);
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/domain/impl/PerfumeDomainServiceImpl.java
@@ -30,8 +30,14 @@ public class PerfumeDomainServiceImpl implements PerfumeDomainService {
     }
 
     @Override
-    public List<Perfume> findAllWithPerfumeAccordsByAccords(List<Accord> accords) {
-        return perfumeRepository.findAllWithPerfumeAccordsByAccords(accords);
+    public List<Perfume> findAllWithPerfumeAccordsByAccords(
+        List<Accord> accords,
+        int maxSize
+    ) {
+        return perfumeRepository.findAllWithPerfumeAccordsByAccords(
+            accords,
+            maxSize
+        );
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/application/perfume/util/RecommendUserAccordsProvider.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/util/RecommendUserAccordsProvider.java
@@ -16,7 +16,7 @@ public class RecommendUserAccordsProvider {
     private static final double[] weights = {-0.9, -0.7, 0.0, 0.8, 1.0};
     private static final Map<String, Double> perfumeAccordScoreMap = new HashMap<>();
 
-    public List<UserAccord> getTopThreeUserAccords(
+    public List<UserAccord> get(
         User user,
         List<StarRating> starRatings
     ) {
@@ -39,7 +39,6 @@ public class RecommendUserAccordsProvider {
 
         return perfumeAccordScoreMap.entrySet().stream()
             .sorted(Map.Entry.<String, Double>comparingByValue().reversed())
-            .limit(3)
             .map(entry -> UserAccord.builder()
                     .user(user)
                     .name(entry.getKey())
@@ -50,7 +49,7 @@ public class RecommendUserAccordsProvider {
     }
 
     private double convert(int score){
-        return score * weights[score-1];
+        return weights[score-1];
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/useraccord/GetTopThreeUserAccordsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/useraccord/GetTopThreeUserAccordsUseCase.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.application.user.port.in.useraccord;
 import com.pikachu.purple.domain.user.UserAccord;
 import java.util.List;
 
-public interface GetUserAccordsUseCase {
+public interface GetTopThreeUserAccordsUseCase {
 
     Result invoke();
 

--- a/src/main/java/com/pikachu/purple/application/user/port/out/UserAccordRepository.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/out/UserAccordRepository.java
@@ -7,6 +7,6 @@ public interface UserAccordRepository {
 
     void createAll(Long userId, List<UserAccord> userAccords);
 
-    List<UserAccord> findAllByUserId(Long userId);
+    List<UserAccord> findAllOrderByScoreDesc(Long userId, int maxSize);
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordApplicationService.java
@@ -28,12 +28,15 @@ public class CreateUserAccordApplicationService implements CreateUserAccordUseCa
         GetUserByIdUseCase.Result user = getUserByIdUseCase.invoke(new GetUserByIdUseCase.Command(userId));
         GetStarRatingsByUserIdUseCase.Result starRatings = getStarRatingsByUserIdUseCase.invoke(new GetStarRatingsByUserIdUseCase.Command(userId));
 
-        List<UserAccord> userAccords = recommendUserAccordsProvider.getTopThreeUserAccords(
+        List<UserAccord> userAccords = recommendUserAccordsProvider.get(
             user.user(),
             starRatings.starRatings()
         );
 
-        userAccordDomainService.createAll(user.user().getId(), userAccords);
+        userAccordDomainService.createAll(
+            user.user().getId(),
+            userAccords
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/GetTopThreeUserAccordsApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/GetTopThreeUserAccordsApplicationService.java
@@ -2,7 +2,7 @@ package com.pikachu.purple.application.user.service.application.useraccord;
 
 import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
 
-import com.pikachu.purple.application.user.port.in.useraccord.GetUserAccordsUseCase;
+import com.pikachu.purple.application.user.port.in.useraccord.GetTopThreeUserAccordsUseCase;
 import com.pikachu.purple.application.user.service.domain.UserAccordDomainService;
 import com.pikachu.purple.domain.user.UserAccord;
 import java.util.List;
@@ -11,14 +11,18 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class GetUserAccordsApplicationService implements GetUserAccordsUseCase {
+public class GetTopThreeUserAccordsApplicationService implements GetTopThreeUserAccordsUseCase {
 
     private final UserAccordDomainService userAccordDomainService;
+    private static final int MAX_SIZE = 3;
 
     @Override
     public Result invoke() {
         Long userId = getCurrentUserAuthentication().userId();
-        List<UserAccord> userAccords = userAccordDomainService.findAllByUserId(userId);
+        List<UserAccord> userAccords = userAccordDomainService.findAllOrderByScoreDesc(
+            userId,
+            MAX_SIZE
+        );
 
         return new Result(userAccords);
     }

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/UserAccordDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/UserAccordDomainService.java
@@ -5,7 +5,10 @@ import java.util.List;
 
 public interface UserAccordDomainService {
 
-    List<UserAccord> findAllByUserId(Long userId);
+    List<UserAccord> findAllOrderByScoreDesc(
+        Long userId,
+        int maxSize
+    );
 
     void createAll(Long userId, List<UserAccord> userAccords);
 

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserAccordDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserAccordDomainServiceImpl.java
@@ -19,8 +19,14 @@ public class UserAccordDomainServiceImpl implements UserAccordDomainService {
     }
 
     @Override
-    public List<UserAccord> findAllByUserId(Long userId) {
-        return userAccordRepository.findAllByUserId(userId);
+    public List<UserAccord> findAllOrderByScoreDesc(
+        Long userId,
+        int maxSize
+    ) {
+        return userAccordRepository.findAllOrderByScoreDesc(
+            userId,
+            maxSize
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/adaptor/PerfumeJpaAdaptor.java
@@ -47,12 +47,17 @@ public class PerfumeJpaAdaptor implements PerfumeRepository {
     }
 
     @Override
-    public List<Perfume> findAllWithPerfumeAccordsByAccords(List<Accord> accords) {
+    public List<Perfume> findAllWithPerfumeAccordsByAccords(
+        List<Accord> accords,
+        int maxSize
+    ) {
         List<AccordJpaEntity> accordJpaEntities = accords.stream()
             .map(AccordJpaEntity::toJpaEntity).toList();
 
         List<PerfumeJpaEntity> perfumeJpaEntities = perfumeJpaRepository.findAllByAccords(
-            accordJpaEntities);
+            accordJpaEntities,
+            Limit.of(maxSize)
+        );
 
         return perfumeJpaEntities.stream()
             .map(PerfumeJpaEntity::toDomainWithPerfumeAccord)

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/perfume/repository/PerfumeJpaRepository.java
@@ -20,8 +20,10 @@ public interface PerfumeJpaRepository extends JpaRepository<PerfumeJpaEntity, Lo
     @Query("select p "
         + "from PerfumeJpaEntity p "
         + "left join PerfumeAccordJpaEntity pa on p = pa.perfumeJpaEntity "
-        + "where pa.accordJpaEntity in :accordJpaEntities")
-    List<PerfumeJpaEntity> findAllByAccords(List<AccordJpaEntity> accordJpaEntities);
+        + "where pa.accordJpaEntity in :accordJpaEntities "
+        + "group by p "
+        + "order by count(pa) desc")
+    List<PerfumeJpaEntity> findAllByAccords(List<AccordJpaEntity> accordJpaEntities, Limit limit);
 
 
     @Query("select p "

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/user/adaptor/UserAccordJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/user/adaptor/UserAccordJpaAdaptor.java
@@ -14,6 +14,7 @@ import com.pikachu.purple.infrastructure.persistence.user.repository.UserAccordJ
 import com.pikachu.purple.infrastructure.persistence.user.repository.UserJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -45,9 +46,14 @@ public class UserAccordJpaAdaptor implements UserAccordRepository {
     }
 
     @Override
-    public List<UserAccord> findAllByUserId(Long userId) {
-        List<UserAccordJpaEntity> userAccordJpaEntities = userAccordJpaRepository.findAllByUserId(
-            userId);
+    public List<UserAccord> findAllOrderByScoreDesc(
+        Long userId,
+        int maxSize
+    ) {
+        List<UserAccordJpaEntity> userAccordJpaEntities = userAccordJpaRepository.findAllByUserIdOrderByScoreDesc(
+            userId,
+            Limit.of(maxSize)
+        );
 
         return userAccordJpaEntities.stream()
             .map(UserAccordJpaEntity::toDomain)

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/user/repository/UserAccordJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/user/repository/UserAccordJpaRepository.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.infrastructure.persistence.user.repository;
 
 import com.pikachu.purple.infrastructure.persistence.user.entity.UserAccordJpaEntity;
 import java.util.List;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,8 @@ public interface UserAccordJpaRepository extends JpaRepository<UserAccordJpaEnti
 
     @Query("select ua "
         + "from UserAccordJpaEntity ua "
-        + "where ua.userJpaEntity.id = :userId")
-    List<UserAccordJpaEntity> findAllByUserId(Long userId);
+        + "where ua.userJpaEntity.id = :userId "
+        + "order by ua.score desc")
+    List<UserAccordJpaEntity> findAllByUserIdOrderByScoreDesc(Long userId, Limit limit);
 
 }


### PR DESCRIPTION
### 진행상황
- 기존 온보딩시 유저 어코드를 최대 5개만 저장했었지만, 불호 노트를 위해 모든 유저 어코드를 저장