### PR TITLE
[PURPLE-172] 향수 별점 평균 계산 로직 추가

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
@@ -8,7 +8,9 @@ import com.pikachu.purple.application.history.service.domain.VisitHistoryDomainS
 import com.pikachu.purple.application.perfume.common.dto.PerfumeDTO;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByIdsUseCase;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByIdsUseCase.Command;
+import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
 import com.pikachu.purple.domain.history.VisitHistory;
+import com.pikachu.purple.domain.perfume.Perfume;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class GetVisitHistoriesApplicationService implements GetVisitHistoriesUse
 
     private final GetPerfumesByIdsUseCase getPerfumesByIdsUseCase;
     private final VisitHistoryDomainService visitHistoryDomainService;
+    private final GetAverageScoreByPerfumeIdUseCase getAverageScoreByPerfumeIdUseCase;
 
     @Transactional
     @Override
@@ -34,6 +37,12 @@ public class GetVisitHistoriesApplicationService implements GetVisitHistoriesUse
             .toList();
 
         GetPerfumesByIdsUseCase.Result result = getPerfumesByIdsUseCase.invoke(new Command(perfumeIds));
+        for (Perfume perfume : result.perfumes()) {
+            double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
+                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+
+            perfume.setAverageScore(averageScore);
+        }
 
         List<PerfumeDTO> perfumeDTOs = result.perfumes().stream()
             .map(PerfumeDTO::from)

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -7,6 +7,7 @@ import com.pikachu.purple.application.perfume.common.dto.UserAccordDTO;
 import com.pikachu.purple.application.perfume.common.vo.PerfumeAccordMatchVO;
 import com.pikachu.purple.application.perfume.port.in.GetPerfumesAndUserAccordsByUserUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
+import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
 import com.pikachu.purple.application.user.port.in.useraccord.GetTopThreeUserAccordsUseCase;
 import com.pikachu.purple.domain.accord.Accord;
 import com.pikachu.purple.domain.perfume.Perfume;
@@ -24,6 +25,8 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
 
     private final PerfumeDomainService perfumeDomainService;
     private final GetTopThreeUserAccordsUseCase getTopThreeUserAccordsUseCase;
+    private final GetAverageScoreByPerfumeIdUseCase getAverageScoreByPerfumeIdUseCase;
+
     private static final int MAX_SIZE = 30;
 
     @Transactional
@@ -54,6 +57,12 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
             accords,
             MAX_SIZE
         );
+
+        for (Perfume perfume : perfumes) {
+            double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
+                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+            perfume.setAverageScore(averageScore);
+        }
 
         List<RecommendedPerfumeDTO> recommendedPerfumeDTOs = perfumes.stream()
             .map(perfume -> {

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
@@ -3,6 +3,7 @@ package com.pikachu.purple.application.perfume.service.application.perfume;
 import com.pikachu.purple.application.perfume.common.dto.PerfumeDTO;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByKeywordUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
+import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
 import com.pikachu.purple.domain.perfume.Perfume;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -14,11 +15,17 @@ import org.springframework.stereotype.Service;
 public class GetPerfumesByKeywordApplicationService implements GetPerfumesByKeywordUseCase {
 
     private final PerfumeDomainService perfumeDomainService;
+    private final GetAverageScoreByPerfumeIdUseCase getAverageScoreByPerfumeIdUseCase;
 
     @Override
     @Transactional
     public Result invoke(Command command) {
         List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByKeyword(command.keyword());
+        for (Perfume perfume : perfumes) {
+            double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
+                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+            perfume.setAverageScore(averageScore);
+        }
 
         List<PerfumeDTO> perfumeDTOs = perfumes.stream()
             .map(PerfumeDTO::from)

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByReviewCountApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByReviewCountApplicationService.java
@@ -3,6 +3,7 @@ package com.pikachu.purple.application.perfume.service.application.perfume;
 import com.pikachu.purple.application.perfume.common.dto.RecommendedPerfumeDTO;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByReviewCountUseCase;
 import com.pikachu.purple.application.perfume.service.domain.PerfumeDomainService;
+import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
 import com.pikachu.purple.domain.perfume.Perfume;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ public class GetPerfumesByReviewCountApplicationService implements
     GetPerfumesByReviewCountUseCase {
 
     private final PerfumeDomainService perfumeDomainService;
+    private final GetAverageScoreByPerfumeIdUseCase getAverageScoreByPerfumeIdUseCase;
 
     private static final int MAX_SIZE = 30;
 
@@ -22,6 +24,11 @@ public class GetPerfumesByReviewCountApplicationService implements
     @Override
     public Result invoke() {
        List<Perfume> perfumes =  perfumeDomainService.findAllOrderByReviewCount(MAX_SIZE);
+        for (Perfume perfume : perfumes) {
+            double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
+                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+            perfume.setAverageScore(averageScore);
+        }
 
        List<RecommendedPerfumeDTO> recommendedPerfumeDTOs = perfumes.stream()
            .map(perfume -> RecommendedPerfumeDTO.from(

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetAverageScoreByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetAverageScoreByPerfumeIdUseCase.java
@@ -1,0 +1,11 @@
+package com.pikachu.purple.application.review.port.in.starrating;
+
+public interface GetAverageScoreByPerfumeIdUseCase {
+
+    Result invoke(Command command);
+
+    record Command(Long perfumeId) {}
+
+    record Result(double averageScore) {}
+
+}

--- a/src/main/java/com/pikachu/purple/application/review/port/out/StarRatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/StarRatingRepository.java
@@ -26,4 +26,6 @@ public interface StarRatingRepository {
 
     List<StarRating> findAllByUpdatedDate(String updatedDate);
 
+    List<StarRating> findAll(Long perfumeId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetAverageScoreByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetAverageScoreByPerfumeIdApplicationService.java
@@ -1,0 +1,24 @@
+package com.pikachu.purple.application.review.service.application.starrating;
+
+import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
+import com.pikachu.purple.application.review.service.domain.StarRatingDomainService;
+import com.pikachu.purple.domain.review.StarRating;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetAverageScoreByPerfumeIdApplicationService implements
+    GetAverageScoreByPerfumeIdUseCase {
+
+    private final StarRatingDomainService starRatingDomainService;
+
+    @Override
+    public Result invoke(Command command) {
+        List<StarRating> starRatings = starRatingDomainService.findAll(command.perfumeId());
+        double totalScore = starRatings.stream().mapToInt(StarRating::getScore).sum();
+        double averageScore = Math.round(totalScore / starRatings.size() * 10) / 10.0;
+        return new Result(averageScore);
+    }
+}

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/StarRatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/StarRatingDomainService.java
@@ -34,4 +34,6 @@ public interface StarRatingDomainService {
 
     List<StarRating> findAllByUpdatedDate(String updatedDate);
 
+    List<StarRating> findAll(Long perfumeId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/StarRatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/StarRatingDomainServiceImpl.java
@@ -95,4 +95,9 @@ public class StarRatingDomainServiceImpl implements StarRatingDomainService {
         return starRatingRepository.findAllByUpdatedDate(updatedDate);
     }
 
+    @Override
+    public List<StarRating> findAll(Long perfumeId) {
+        return starRatingRepository.findAll(perfumeId);
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/domain/perfume/Perfume.java
+++ b/src/main/java/com/pikachu/purple/domain/perfume/Perfume.java
@@ -15,6 +15,8 @@ public class Perfume {
     private Long id;
     private String name;
     private String imageUrl;
+    // TODO: averageScore 관련 로직 리팩토링 후 제거
+    @Setter
     private double averageScore;
     private Brand brand;
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/StarRatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/StarRatingJpaAdaptor.java
@@ -147,4 +147,10 @@ public class StarRatingJpaAdaptor implements StarRatingRepository {
             .toList();
     }
 
+    @Override
+    public List<StarRating> findAll(Long perfumeId) {
+        List<StarRatingJpaEntity> starRatingJpaEntities = starRatingJpaRepository.findAllByPerfumeId(perfumeId);
+        return starRatingJpaEntities.stream().map(StarRatingJpaEntity::toDomain).toList();
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/StarRatingJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/StarRatingJpaRepository.java
@@ -21,5 +21,9 @@ public interface StarRatingJpaRepository extends JpaRepository<StarRatingJpaEnti
         + "where FUNCTION('DATE_FORMAT', sr.updatedAt, '%Y%m%d') = :updatedDate "
         + "order by sr.perfumeJpaEntity.id asc, sr.score asc")
     List<StarRatingJpaEntity> findAllByUpdatedDate(String updatedDate);
-    
+
+    @Query("select sr "
+        + "from StarRatingJpaEntity sr "
+        + "where sr.perfumeJpaEntity.id = :perfumeId")
+    List<StarRatingJpaEntity> findAllByPerfumeId(Long perfumeId);
 }


### PR DESCRIPTION
## 진행 사항
- 향수 별점 평균 산출 UseCase 추가
    - 향수 ID를 기준으로 해당 별점 전부 select
    - score 합산 / 별점 개수, 소숫점 첫번째 자리수까지
- PerfumeDTO, RecommendedPerfumeDTO 관련으로 평점 산출 로직 적용

### 추후 작업 필요
- 평점 산출 로직 개선 필요
    - 별점 업데이터 되는 경우 바로 평점 반영 후 DB 내 perfume.averate_score 업데이트

### 작업 결과
<img width="522" alt="스크린샷 2024-10-29 오후 9 18 46" src="https://github.com/user-attachments/assets/72682d5f-6fce-48e4-8fff-54adcc855dc3">
