### PR TITLE
[PURPLE-186] 자신이 작성한 리뷰 전체 조회 API

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewDTO.java
+++ b/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewDTO.java
@@ -1,16 +1,16 @@
 package com.pikachu.purple.application.review.common.dto;
 
+import com.pikachu.purple.application.util.DateUtil;
 import com.pikachu.purple.application.util.IdUtil;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.enums.ReviewType;
-import java.time.Instant;
 import java.util.List;
 
 public record ReviewDTO(
     String reviewId,
     String nickname,
     String imageUrl,
-    Instant date,
+    String date,
     ReviewType reviewType,
     int score,
     String content,
@@ -32,7 +32,7 @@ public record ReviewDTO(
             IdUtil.toString(review.getId()),
             review.getUser().getNickname(),
             review.getUser().getImageUrl(),
-            review.getUpdatedAt(),
+            DateUtil.toString(review.getUpdatedAt()),
             review.getType(),
             review.getStarRating().getScore(),
             review.getContent(),

--- a/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewWithPerfumeDTO.java
+++ b/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewWithPerfumeDTO.java
@@ -1,0 +1,66 @@
+package com.pikachu.purple.application.review.common.dto;
+
+import com.pikachu.purple.application.util.DateUtil;
+import com.pikachu.purple.application.util.IdUtil;
+import com.pikachu.purple.domain.review.StarRating;
+import com.pikachu.purple.domain.review.enums.ReviewType;
+import java.util.List;
+
+public record ReviewWithPerfumeDTO(
+    String reviewId,
+    String brandName,
+    String perfumeId,
+    String perfumeName,
+    String perfumeImageUrl,
+    ReviewType reviewType,
+    int score,
+    String content,
+    List<ReviewEvaluationFieldDTO> perfumeEvaluations,
+    List<String> moodNames,
+    Boolean isComplained,
+    Boolean isLiked,
+    Integer likeCount,
+    String date
+) {
+    public static ReviewWithPerfumeDTO of(
+        StarRating starRating,
+        List<ReviewEvaluationFieldDTO> perfumeEvaluations,
+        List<String> moodNames
+    ) {
+        return new ReviewWithPerfumeDTO(
+            IdUtil.toString(starRating.getReview().getId()),
+            starRating.getReview().getPerfume().getBrand().getName(),
+            IdUtil.toString(starRating.getPerfume().getId()),
+            starRating.getReview().getPerfume().getName(),
+            starRating.getReview().getPerfume().getImageUrl(),
+            starRating.getReview().getType(),
+            starRating.getScore(),
+            starRating.getReview().getContent(),
+            perfumeEvaluations,
+            moodNames,
+            starRating.getReview().isComplained(),
+            starRating.getReview().isLiked(),
+            starRating.getReview().getLikeCount(),
+            DateUtil.toString(starRating.getReview().getUpdatedAt())
+        );
+    }
+
+    public static ReviewWithPerfumeDTO from(StarRating starRating) {
+        return new ReviewWithPerfumeDTO(
+            null,
+            starRating.getPerfume().getBrand().getName(),
+            IdUtil.toString(starRating.getPerfume().getId()),
+            starRating.getPerfume().getName(),
+            starRating.getPerfume().getImageUrl(),
+            null,
+            starRating.getScore(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            DateUtil.toString(starRating.getUpdatedAt())
+        );
+    }
+}

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetReviewsByUserAndSortTypeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetReviewsByUserAndSortTypeUseCase.java
@@ -1,0 +1,14 @@
+package com.pikachu.purple.application.review.port.in.starrating;
+
+import com.pikachu.purple.application.review.common.dto.ReviewWithPerfumeDTO;
+import java.util.List;
+
+public interface GetReviewsByUserAndSortTypeUseCase {
+
+    Result invoke(Command command);
+
+    record Command(String sortType) {}
+
+    record Result(List<ReviewWithPerfumeDTO> reviewWithPerfumeDTOs) {}
+
+}

--- a/src/main/java/com/pikachu/purple/application/review/port/out/StarRatingRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/StarRatingRepository.java
@@ -28,4 +28,12 @@ public interface StarRatingRepository {
 
     List<StarRating> findAll(Long perfumeId);
 
+    List<StarRating> findAllOrderByLikeCountDesc(Long userId);
+
+    List<StarRating> findAllByUserId(Long userId);
+
+    List<StarRating> findAllOrderByScoreDesc(Long userId);
+
+    List<StarRating> findALlOrderByScoreAsc(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetReviewsByUserAndSortTypeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetReviewsByUserAndSortTypeApplicationService.java
@@ -1,0 +1,90 @@
+package com.pikachu.purple.application.review.service.application.starrating;
+
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
+import com.pikachu.purple.application.review.common.dto.ReviewEvaluationFieldDTO;
+import com.pikachu.purple.application.review.common.dto.ReviewEvaluationOptionDTO;
+import com.pikachu.purple.application.review.common.dto.ReviewWithPerfumeDTO;
+import com.pikachu.purple.application.review.port.in.starrating.GetReviewsByUserAndSortTypeUseCase;
+import com.pikachu.purple.application.review.service.domain.StarRatingDomainService;
+import com.pikachu.purple.domain.review.Mood;
+import com.pikachu.purple.domain.review.StarRating;
+import com.pikachu.purple.domain.review.enums.SortType;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetReviewsByUserAndSortTypeApplicationService implements
+    GetReviewsByUserAndSortTypeUseCase {
+
+    private final StarRatingDomainService starRatingDomainService;
+
+    @Transactional
+    @Override
+    public Result invoke(Command command) {
+        Long userId = getCurrentUserAuthentication().userId();
+        SortType sortType = SortType.transByStr(command.sortType());
+
+        List<StarRating> starRatings = new ArrayList<>();
+        switch (sortType) {
+            case LIKED:
+                starRatings = starRatingDomainService.findAllOrderByLikeCountDesc(userId);
+                break;
+            case LATEST:
+                starRatings = starRatingDomainService.findAllByUserId(userId);
+
+                starRatings = starRatings.stream()
+                    .sorted(Comparator.comparing(
+                        (StarRating sr) -> sr.getReview() != null ? sr.getReview().getUpdatedAt() : sr.getUpdatedAt()
+                    ).reversed())
+                    .toList();
+                break;
+            case STAR_RATING_HIGH:
+                starRatings = starRatingDomainService.findAllOrderByScoreDesc(userId);
+                break;
+            case STAR_RATING_LOW:
+                starRatings = starRatingDomainService.findAllOrderByScoreAsc(userId);
+                break;
+            default:
+                break;
+        }
+
+        List<ReviewWithPerfumeDTO> reviewWithPerfumeDTOs = starRatings.stream()
+            .map(starRating -> {
+                if (starRating.getReview() != null) {
+                    List<ReviewEvaluationFieldDTO> reviewEvaluations = starRating.getReview().getEvaluation()
+                        .getFields(starRating.getReview().getId()).stream()
+                        .map(fieldType -> ReviewEvaluationFieldDTO.of(
+                            fieldType,
+                            starRating.getReview().getEvaluation().getOptions(
+                                    starRating.getReview().getId(),
+                                    fieldType
+                                ).stream()
+                                .map(ReviewEvaluationOptionDTO::of)
+                                .toList()
+                        )).toList();
+
+                    List<String> moodNames = starRating.getReview().getMoods().stream()
+                        .map(Mood::getName)
+                        .toList();
+
+                    return ReviewWithPerfumeDTO.of(
+                        starRating,
+                        reviewEvaluations,
+                        moodNames
+                    );
+                } else {
+                   return ReviewWithPerfumeDTO.from(starRating);
+                }
+            })
+            .toList();
+
+        return new Result(reviewWithPerfumeDTOs);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/StarRatingDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/StarRatingDomainService.java
@@ -36,4 +36,12 @@ public interface StarRatingDomainService {
 
     List<StarRating> findAll(Long perfumeId);
 
+    List<StarRating> findAllOrderByLikeCountDesc(Long userId);
+
+    List<StarRating> findAllByUserId(Long userId);
+
+    List<StarRating> findAllOrderByScoreDesc(Long userId);
+
+    List<StarRating> findAllOrderByScoreAsc(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/StarRatingDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/StarRatingDomainServiceImpl.java
@@ -100,4 +100,24 @@ public class StarRatingDomainServiceImpl implements StarRatingDomainService {
         return starRatingRepository.findAll(perfumeId);
     }
 
+    @Override
+    public List<StarRating> findAllOrderByLikeCountDesc(Long userId) {
+        return starRatingRepository.findAllOrderByLikeCountDesc(userId);
+    }
+
+    @Override
+    public List<StarRating> findAllByUserId(Long userId) {
+        return starRatingRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public List<StarRating> findAllOrderByScoreDesc(Long userId) {
+        return starRatingRepository.findAllOrderByScoreDesc(userId);
+    }
+
+    @Override
+    public List<StarRating> findAllOrderByScoreAsc(Long userId) {
+        return starRatingRepository.findALlOrderByScoreAsc(userId);
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/application/util/DateUtil.java
+++ b/src/main/java/com/pikachu/purple/application/util/DateUtil.java
@@ -1,0 +1,17 @@
+package com.pikachu.purple.application.util;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class DateUtil {
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+
+    public static String toString(Instant date) {
+        return formatter.format(date);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
@@ -138,7 +138,7 @@ public interface UserApi {
     @Secured
     @Operation(summary = "작성한 리뷰 전체 조회")
     @GetMapping("/my/reviews")
-    SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUser(@RequestParam("sort-type") String sortType);
+    SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUserAndSortType(@RequestParam("sort-type") String sortType);
 
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
@@ -3,6 +3,7 @@ package com.pikachu.purple.bootstrap.user.api;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.common.security.Secured;
 import com.pikachu.purple.bootstrap.user.dto.response.GetPolarizedUserAccordsByUserResponse;
+import com.pikachu.purple.bootstrap.user.dto.response.GetReviewsByUserAndSortTypeResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetTopThreeReviewedBrandsResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetUserReviewCountsResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetReviewByPerfumeIdAndUserResponse;
@@ -133,5 +134,11 @@ public interface UserApi {
     @GetMapping("/my/profile")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<GetUserProfileResponse> findUserProfileByUser();
+
+    @Secured
+    @Operation(summary = "작성한 리뷰 전체 조회")
+    @GetMapping("/my/reviews")
+    SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUser(@RequestParam("sort-type") String sortType);
+
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -149,7 +149,7 @@ public class UserController implements UserApi {
     }
 
     @Override
-    public SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUser(String sortType) {
+    public SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUserAndSortType(String sortType) {
         GetReviewsByUserAndSortTypeUseCase.Result result = getReviewsByUserAndSortTypeUseCase.invoke(new GetReviewsByUserAndSortTypeUseCase.Command(sortType));
 
         return SuccessResponse.of(

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.pikachu.purple.application.history.port.in.visithistory.CreateVisitHi
 import com.pikachu.purple.application.history.port.in.visithistory.DeleteVisitHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.visithistory.GetVisitHistoriesUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetReviewByPerfumeIdAndUserUseCase;
+import com.pikachu.purple.application.review.port.in.starrating.GetReviewsByUserAndSortTypeUseCase;
 import com.pikachu.purple.application.user.port.in.user.GetUserProfileByUserUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetTopThreeReviewedBrandsUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetUserReviewCountsUseCase;
@@ -15,6 +16,7 @@ import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.user.api.UserApi;
 import com.pikachu.purple.bootstrap.user.dto.response.GetPolarizedUserAccordsByUserResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetReviewByPerfumeIdAndUserResponse;
+import com.pikachu.purple.bootstrap.user.dto.response.GetReviewsByUserAndSortTypeResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetSearchHistoriesResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetTopThreeReviewedBrandsResponse;
 import com.pikachu.purple.bootstrap.user.dto.response.GetUserProfileResponse;
@@ -40,6 +42,7 @@ public class UserController implements UserApi {
     private final GetReviewByPerfumeIdAndUserUseCase getReviewByPerfumeIdAndUserUseCase;
     private final GetPolarizedUserAccordsByUserUseCase getPolarizedUserAccordsByUserUseCase;
     private final GetUserProfileByUserUseCase getUserProfileByUserUseCase;
+    private final GetReviewsByUserAndSortTypeUseCase getReviewsByUserAndSortTypeUseCase;
 
     @Override
     public SuccessResponse<GetUserProfileResponse> updateProfile(
@@ -143,6 +146,15 @@ public class UserController implements UserApi {
                 result.imageUrl(),
                 result.email()
         ));
+    }
+
+    @Override
+    public SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUser(String sortType) {
+        GetReviewsByUserAndSortTypeUseCase.Result result = getReviewsByUserAndSortTypeUseCase.invoke(new GetReviewsByUserAndSortTypeUseCase.Command(sortType));
+
+        return SuccessResponse.of(
+            new GetReviewsByUserAndSortTypeResponse(result.reviewWithPerfumeDTOs())
+        );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/dto/response/GetReviewsByUserAndSortTypeResponse.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/dto/response/GetReviewsByUserAndSortTypeResponse.java
@@ -1,0 +1,8 @@
+package com.pikachu.purple.bootstrap.user.dto.response;
+
+import com.pikachu.purple.application.review.common.dto.ReviewWithPerfumeDTO;
+import java.util.List;
+
+public record GetReviewsByUserAndSortTypeResponse(List<ReviewWithPerfumeDTO> reviews) {
+
+}

--- a/src/main/java/com/pikachu/purple/domain/review/StarRating.java
+++ b/src/main/java/com/pikachu/purple/domain/review/StarRating.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.domain.review;
 
 import com.pikachu.purple.domain.perfume.Perfume;
 import com.pikachu.purple.domain.user.User;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,15 +16,23 @@ public class StarRating {
 
     private Long id;
     private int score;
+    private Instant updatedAt;
 
     @Setter
     private User user;
     @Setter
     private Perfume perfume;
+    @Setter
+    private Review review;
 
-    public StarRating(Long id, int score) {
+    public StarRating(
+        Long id,
+        int score,
+        Instant updatedAt
+    ) {
         this.id = id;
         this.score = score;
+        this.updatedAt = updatedAt;
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/StarRatingJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/StarRatingJpaAdaptor.java
@@ -153,4 +153,64 @@ public class StarRatingJpaAdaptor implements StarRatingRepository {
         return starRatingJpaEntities.stream().map(StarRatingJpaEntity::toDomain).toList();
     }
 
+    @Override
+    public List<StarRating> findAllOrderByLikeCountDesc(Long userId) {
+        List<StarRatingJpaEntity> starRatingJpaEntities = starRatingJpaRepository.findAllOrderByLikeCountDesc(userId);
+
+        return starRatingJpaEntities.stream()
+            .map(starRatingJpaEntity -> {
+                if (starRatingJpaEntity.getReviewJpaEntity() != null) {
+                    return StarRatingJpaEntity.toFullDomain(starRatingJpaEntity, userId);
+                } else {
+                    return StarRatingJpaEntity.toDomainWithPerfume(starRatingJpaEntity);
+                }
+            })
+            .toList();
+    }
+
+    @Override
+    public List<StarRating> findAllByUserId(Long userId) {
+        List<StarRatingJpaEntity> starRatingJpaEntities = starRatingJpaRepository.findAllByUserId(userId);
+
+        return starRatingJpaEntities.stream()
+            .map(starRatingJpaEntity -> {
+                if (starRatingJpaEntity.getReviewJpaEntity() != null) {
+                    return StarRatingJpaEntity.toFullDomain(starRatingJpaEntity, userId);
+                } else {
+                    return StarRatingJpaEntity.toDomainWithPerfume(starRatingJpaEntity);
+                }
+            })
+            .toList();
+    }
+
+    @Override
+    public List<StarRating> findAllOrderByScoreDesc(Long userId) {
+        List<StarRatingJpaEntity> starRatingJpaEntities = starRatingJpaRepository.findAllOrderByScoreDesc(userId);
+
+        return starRatingJpaEntities.stream()
+            .map(starRatingJpaEntity -> {
+                if (starRatingJpaEntity.getReviewJpaEntity() != null) {
+                    return StarRatingJpaEntity.toFullDomain(starRatingJpaEntity, userId);
+                } else {
+                    return StarRatingJpaEntity.toDomainWithPerfume(starRatingJpaEntity);
+                }
+            })
+            .toList();
+    }
+
+    @Override
+    public List<StarRating> findALlOrderByScoreAsc(Long userId) {
+        List<StarRatingJpaEntity> starRatingJpaEntities = starRatingJpaRepository.findAllOrderByScoreAsc(userId);
+
+        return starRatingJpaEntities.stream()
+            .map(starRatingJpaEntity -> {
+                if (starRatingJpaEntity.getReviewJpaEntity() != null) {
+                    return StarRatingJpaEntity.toFullDomain(starRatingJpaEntity, userId);
+                } else {
+                    return StarRatingJpaEntity.toDomainWithPerfume(starRatingJpaEntity);
+                }
+            })
+            .toList();
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/StarRatingJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/entity/StarRatingJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,6 +41,13 @@ public class StarRatingJpaEntity extends BaseEntity {
     @Column(name = "score")
     private int score;
 
+    @OneToOne(
+        mappedBy = "starRatingJpaEntity",
+        fetch = FetchType.LAZY
+    )
+    private ReviewJpaEntity reviewJpaEntity;
+
+
     public void updateScore(int score) {
         this.score = score;
     }
@@ -47,7 +55,8 @@ public class StarRatingJpaEntity extends BaseEntity {
     public static StarRating toDomain(StarRatingJpaEntity jpaEntity) {
         StarRating domain = new StarRating(
             jpaEntity.getId(),
-            jpaEntity.getScore()
+            jpaEntity.getScore(),
+            jpaEntity.getUpdatedAt()
         );
         domain.setUser(UserJpaEntity.toDummy(jpaEntity.getUserJpaEntity()));
         domain.setPerfume(PerfumeJpaEntity.toDummy(jpaEntity.getPerfumeJpaEntity()));
@@ -59,6 +68,19 @@ public class StarRatingJpaEntity extends BaseEntity {
         StarRating domain = toDomain(jpaEntity);
         domain.setPerfume(PerfumeJpaEntity.toDomainWithPerfumeAccord(jpaEntity.getPerfumeJpaEntity()));
 
+        return domain;
+    }
+
+    public static StarRating toDomainWithPerfume(StarRatingJpaEntity jpaEntity) {
+        StarRating domain = toDomain(jpaEntity);
+        domain.setPerfume(PerfumeJpaEntity.toDomain(jpaEntity.getPerfumeJpaEntity()));
+
+        return domain;
+    }
+
+    public static StarRating toFullDomain(StarRatingJpaEntity jpaEntity, Long userId) {
+        StarRating domain = toDomain(jpaEntity);
+        domain.setReview(ReviewJpaEntity.toFullDomain(jpaEntity.getReviewJpaEntity(), userId));
         return domain;
     }
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/StarRatingJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/StarRatingJpaRepository.java
@@ -26,4 +26,28 @@ public interface StarRatingJpaRepository extends JpaRepository<StarRatingJpaEnti
         + "from StarRatingJpaEntity sr "
         + "where sr.perfumeJpaEntity.id = :perfumeId")
     List<StarRatingJpaEntity> findAllByPerfumeId(Long perfumeId);
+
+    @Query("select sr "
+        + "from StarRatingJpaEntity sr "
+        + "where sr.userJpaEntity.id = :userId")
+    List<StarRatingJpaEntity> findAllByUserId(Long userId);
+
+    @Query("select sr "
+        + "from StarRatingJpaEntity sr "
+        + "left join ReviewJpaEntity re on sr = re.starRatingJpaEntity "
+        + "where sr.userJpaEntity.id = :userId "
+        + "order by re.likeCount desc")
+    List<StarRatingJpaEntity> findAllOrderByLikeCountDesc(Long userId);
+
+    @Query("select sr "
+        + "from StarRatingJpaEntity sr "
+        + "where sr.userJpaEntity.id = :userId "
+        + "order by sr.score desc")
+    List<StarRatingJpaEntity> findAllOrderByScoreDesc(Long userId);
+
+    @Query("select sr "
+        + "from StarRatingJpaEntity sr "
+        + "where sr.userJpaEntity.id = :userId "
+        + "order by sr.score asc")
+    List<StarRatingJpaEntity> findAllOrderByScoreAsc(Long userId);
 }


### PR DESCRIPTION
### 진행상황
- 자신이 작성한 리뷰를 전체 조회합니다.
  - 온보딩때 평가한 값까지 포함합니다.
- 최신순으로 조회할 때 수정된 날짜를 기준으로 비교합니다.
- 온보딩때 평가한 값을 간단한/자세한 리뷰로 변경하기 위해 반환값에 perfumeId를 추가했습니다.
  - 간단한/자세한 리뷰로 변환을 할 때는 간단한/자세한 리뷰 생성 API를 사용합니다. 