### PR TITLE
[PURPLE-188] 리뷰 삭제 API 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteAllLikeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteAllLikeUseCase.java
@@ -1,0 +1,9 @@
+package com.pikachu.purple.application.review.port.in.like;
+
+public interface DeleteAllLikeUseCase {
+
+    void invoke(Command command);
+
+    record Command(Long reviewId) {}
+
+}

--- a/src/main/java/com/pikachu/purple/application/review/port/out/LikeRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/LikeRepository.java
@@ -12,4 +12,6 @@ public interface LikeRepository {
 
     void delete(Long userId, Long reviewId);
 
+    void deleteAll(Long reviewId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteAllLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteAllLikeApplicationService.java
@@ -1,0 +1,23 @@
+package com.pikachu.purple.application.review.service.application.like;
+
+import com.pikachu.purple.application.review.port.in.like.DeleteAllLikeUseCase;
+import com.pikachu.purple.application.review.service.domain.LikeDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAllLikeApplicationService implements DeleteAllLikeUseCase {
+
+    private final LikeDomainService likeDomainService;
+
+    @Transactional
+    @Override
+    public void invoke(Command command) {
+
+        likeDomainService.deleteAll(command.reviewId());
+
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.application.review.service.application.review;
 
+import com.pikachu.purple.application.review.port.in.like.DeleteAllLikeUseCase;
 import com.pikachu.purple.application.review.port.in.review.DeleteReviewUseCase;
 import com.pikachu.purple.application.review.port.in.starrating.DeleteStarRatingUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
@@ -20,11 +21,11 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
     private final ReviewEvaluationDomainService reviewEvaluationDomainService;
     private final DeleteStarRatingUseCase deleteStarRatingUseCase;
     private final DecreaseEvaluationStatisticUseCase decreaseEvaluationStatisticUseCase;
+    private final DeleteAllLikeUseCase deleteAllLikeUseCase;
 
     @Transactional
     @Override
     public void invoke(Command command) {
-
         Review review = reviewDomainService.find(command.reviewId());
 
         deleteStarRatingUseCase.invoke(
@@ -45,6 +46,7 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
             reviewDomainService.deleteReviewMoods(command.reviewId());
         }
 
+        deleteAllLikeUseCase.invoke(new DeleteAllLikeUseCase.Command(command.reviewId()));
         reviewDomainService.delete(command.reviewId());
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/LikeDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/LikeDomainService.java
@@ -24,4 +24,6 @@ public interface LikeDomainService {
         Long reviewId
     );
 
+    void deleteAll(Long reviewId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/LikeDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/LikeDomainServiceImpl.java
@@ -53,4 +53,9 @@ public class LikeDomainServiceImpl implements LikeDomainService {
         );
     }
 
+    @Override
+    public void deleteAll(Long reviewId) {
+        likeRepository.deleteAll(reviewId);
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/LikeJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/LikeJpaAdaptor.java
@@ -13,6 +13,7 @@ import com.pikachu.purple.infrastructure.persistence.review.repository.LikeJpaRe
 import com.pikachu.purple.infrastructure.persistence.review.repository.ReviewJpaRepository;
 import com.pikachu.purple.infrastructure.persistence.user.entity.UserJpaEntity;
 import com.pikachu.purple.infrastructure.persistence.user.repository.UserJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -78,6 +79,13 @@ public class LikeJpaAdaptor implements LikeRepository {
         ).orElseThrow(() -> LikeNotFoundException);
 
         likeJpaRepository.delete(likeJpaEntity);
+    }
+
+    @Override
+    public void deleteAll(Long reviewId) {
+        List<LikeJpaEntity> likeJpaEntities = likeJpaRepository.findAllByReviewId(reviewId);
+
+        likeJpaRepository.deleteAll(likeJpaEntities);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/LikeJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/LikeJpaRepository.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.infrastructure.persistence.review.repository;
 
 import com.pikachu.purple.infrastructure.persistence.review.entity.LikeJpaEntity;
 import com.pikachu.purple.infrastructure.persistence.review.entity.id.LikeId;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,8 @@ public interface LikeJpaRepository extends JpaRepository<LikeJpaEntity, LikeId> 
         + "where l.userJpaEntity.id = :userId and l.reviewJpaEntity.id = :reviewId")
     Optional<LikeJpaEntity> findByUserIdAndReviewId(Long userId, Long reviewId);
 
+    @Query("select l "
+        + "from LikeJpaEntity l "
+        + "where l.reviewJpaEntity.id = :reviewId")
+    List<LikeJpaEntity> findAllByReviewId(Long reviewId);
 }


### PR DESCRIPTION
### 진행상황
- 좋아요가 리뷰를 참조하고 있기 때문에, 리뷰에 대한 좋아요 데이터가 존재할 경우 좋아요를 삭제하지 않고 리뷰를 삭제할 시 무결성 보장에 따라 에러가 발생합니다.
- 리뷰를 삭제하기 전 리뷰에 해당하는 좋아요를 삭제하는 로직을 추가했습니다.