### PR TITLE
[PURPLE-189] 카카오 로그인 redirect uri 서버로 변경

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
@@ -1,17 +1,10 @@
 package com.pikachu.purple.application.user.port.in;
 
-import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-
 public interface SocialLoginUseCase {
 
     Result invoke(SocialLoginUseCase.Command command);
 
-    record Command(
-        SocialLoginProvider socialLoginProvider,
-        String authorizationCode
-    ) {
-
-    }
+    record Command(String authorizationCode) {}
 
     record Result(
         String jwtToken,

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
@@ -8,6 +8,7 @@ import com.pikachu.purple.application.user.service.util.SocialLoginService;
 import com.pikachu.purple.application.user.service.util.UserTokenService;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.domain.user.User;
+import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import com.pikachu.purple.domain.user.vo.SocialLoginToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,20 +30,20 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
     @Override
     public Result invoke(Command command) {
         SocialLoginToken socialLoginToken = socialLoginService.getToken(
-            command.socialLoginProvider(),
+            SocialLoginProvider.KAKAO,
             command.authorizationCode()
         );
 
         IdToken idTokenClaims = userTokenService.resolveIdToken(
             socialLoginToken.idToken(),
-            command.socialLoginProvider()
+            SocialLoginProvider.KAKAO
         );
 
         String email = idTokenClaims.getEmail().replace("\"", "");
 
         User user = userDomainService.findByEmailAndSocialLoginProvider(
             email,
-            command.socialLoginProvider()
+            SocialLoginProvider.KAKAO
         );
 
         boolean isSignUp = false;
@@ -52,13 +53,13 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
             userSignUpUseCase.invoke(
                 new UserSignUpUseCase.Command(
                     email,
-                    command.socialLoginProvider()
+                    SocialLoginProvider.KAKAO
                 )
             );
 
             user = userDomainService.findByEmailAndSocialLoginProvider(
                 email,
-                command.socialLoginProvider()
+                SocialLoginProvider.KAKAO
             );
         }
 

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -5,12 +5,11 @@ import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
-import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URISyntaxException;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,17 +21,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public interface AuthApi {
 
     @Operation(summary = "소셜 로그인 URI 발급")
-    @PostMapping("/login-try/{provider}")
+    @PostMapping("/login-try")
     @ResponseStatus(HttpStatus.OK)
-    SuccessResponse<SocialLoginTryResponse> socialLoginTry(
-        @PathVariable("provider") SocialLoginProvider provider
-    ) throws URISyntaxException;
+    SuccessResponse<SocialLoginTryResponse> socialLoginTry() throws URISyntaxException;
 
     @Operation(summary = "소셜 로그인")
-    @PostMapping("/login/{provider}")
+    @GetMapping("/login/kakao")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<SocialLoginResponse> socialLogin(
-        @PathVariable("provider") SocialLoginProvider provider,
         @RequestParam String code
     );
 

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -23,11 +23,10 @@ public class AuthController implements AuthApi {
     private final RefreshJwtTokenUseCase refreshJwtTokenUseCase;
 
     @Override
-    public SuccessResponse<SocialLoginTryResponse> socialLoginTry(
-        SocialLoginProvider socialLoginProvider)
+    public SuccessResponse<SocialLoginTryResponse> socialLoginTry()
         throws URISyntaxException {
         SocialLoginTryUseCase.Result result = socialLoginTryUseCase.invoke(
-            new SocialLoginTryUseCase.Command(socialLoginProvider)
+            new SocialLoginTryUseCase.Command(SocialLoginProvider.KAKAO)
         );
 
         return SuccessResponse.of(
@@ -37,14 +36,10 @@ public class AuthController implements AuthApi {
 
     @Override
     public SuccessResponse<SocialLoginResponse> socialLogin(
-        SocialLoginProvider provider,
         String code
     ) {
         SocialLoginUseCase.Result result = socialLoginUseCase.invoke(
-            new SocialLoginUseCase.Command(
-                provider,
-                code
-            )
+            new SocialLoginUseCase.Command(code)
         );
 
         return SuccessResponse.of(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,7 +82,7 @@ auth:
     client-id: ${KAKAO_CLIENT_ID}
     response-type: code
     authorize-uri: https://kauth.kakao.com/oauth/authorize
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/perpicks/auth/login/kakao}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080/perpicks/auth/login/kakao}
     jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
 
 uri:


### PR DESCRIPTION
### 진행상황
- 로컬, 서버환경에서 카카오 로그인 api를 테스트할 수 있도록 기존 프론트로 리다이렉션하는 방식을 서버로 리다이렉션하여 어느 환경에서나 테스트할 수 있도록 수정하였습니다.