### PR TITLE
[PURPLE-193] 카카오 로그인 API 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginTryUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginTryUseCase.java
@@ -5,18 +5,15 @@ import java.net.URISyntaxException;
 
 public interface SocialLoginTryUseCase {
 
-    Result invoke(SocialLoginTryUseCase.Command command) throws URISyntaxException;
+    Result invoke(Command command) throws URISyntaxException;
 
     record Command(
-        SocialLoginProvider socialLoginProvider
-    ) {
-
-    }
+        SocialLoginProvider socialLoginProvider,
+        String frontUrl
+    ) {}
 
     record Result(
         String socialLoginUrl
-    ) {
-
-    }
+    ) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
@@ -8,7 +8,8 @@ public interface SocialLoginUseCase {
 
     record Command(
         SocialLoginProvider socialLoginProvider,
-        String authorizationCode
+        String authorizationCode,
+        String frontUrl
     ) {}
 
     record Result(

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
@@ -8,7 +8,6 @@ import com.pikachu.purple.application.user.service.util.SocialLoginService;
 import com.pikachu.purple.application.user.service.util.UserTokenService;
 import com.pikachu.purple.application.user.vo.tokens.IdToken;
 import com.pikachu.purple.domain.user.User;
-import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import com.pikachu.purple.domain.user.vo.SocialLoginToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
@@ -31,7 +31,8 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
     public Result invoke(Command command) {
         SocialLoginToken socialLoginToken = socialLoginService.getToken(
             command.socialLoginProvider(),
-            command.authorizationCode()
+            command.authorizationCode(),
+            command.frontUrl()
         );
 
         IdToken idTokenClaims = userTokenService.resolveIdToken(

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginTryApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginTryApplicationService.java
@@ -14,9 +14,12 @@ public class SocialLoginTryApplicationService implements SocialLoginTryUseCase {
     private final SocialLoginService socialLoginService;
 
     @Override
-    public SocialLoginTryUseCase.Result invoke(SocialLoginTryUseCase.Command command)
+    public SocialLoginTryUseCase.Result invoke(Command command)
         throws URISyntaxException {
-        URI socialLoginUri = socialLoginService.createUri(command.socialLoginProvider());
+        URI socialLoginUri = socialLoginService.createUri(
+            command.socialLoginProvider(),
+            command.frontUrl()
+        );
 
         return new SocialLoginTryUseCase.Result(socialLoginUri.toString());
     }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/SocialLoginService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/SocialLoginService.java
@@ -7,11 +7,15 @@ import java.net.URISyntaxException;
 
 public interface SocialLoginService {
 
-    URI createUri(SocialLoginProvider socialLoginProvider) throws URISyntaxException;
+    URI createUri(
+        SocialLoginProvider socialLoginProvider,
+        String frontUrl
+    ) throws URISyntaxException;
 
     SocialLoginToken getToken(
         SocialLoginProvider socialLoginProvider,
-        String authorizationCode
+        String authorizationCode,
+        String frontUrl
     );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/SocialLoginServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/SocialLoginServiceImpl.java
@@ -19,11 +19,14 @@ public class SocialLoginServiceImpl implements SocialLoginService {
     private final SocialLoginStrategyFactory socialLoginStrategyFactory;
 
     @Override
-    public URI createUri(SocialLoginProvider socialLoginProvider) throws URISyntaxException {
+    public URI createUri(
+        SocialLoginProvider socialLoginProvider,
+        String frontUrl
+    ) throws URISyntaxException {
         SocialLoginStrategy socialLoginUriStrategy = socialLoginStrategyFactory.getStrategy(
             socialLoginProvider);
 
-        URI uri = socialLoginUriStrategy.getUrl();
+        URI uri = socialLoginUriStrategy.getUrl(frontUrl);
 
         UUID stateCode = generateState();
 
@@ -33,12 +36,16 @@ public class SocialLoginServiceImpl implements SocialLoginService {
     @Override
     public SocialLoginToken getToken(
         SocialLoginProvider socialLoginProvider,
-        String authorizationCode
+        String authorizationCode,
+        String frontUrl
     ) {
         SocialLoginStrategy socialLoginUriStrategy = socialLoginStrategyFactory.getStrategy(
             socialLoginProvider);
 
-        return socialLoginUriStrategy.getToken(authorizationCode);
+        return socialLoginUriStrategy.getToken(
+            authorizationCode,
+            frontUrl
+        );
     }
 
     private UUID generateState() {

--- a/src/main/java/com/pikachu/purple/application/user/service/util/strategy/KakaoSocialLoginStrategy.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/strategy/KakaoSocialLoginStrategy.java
@@ -30,31 +30,39 @@ public class KakaoSocialLoginStrategy implements SocialLoginStrategy {
     private final SocialLoginPort socialLoginPort;
 
     @Override
-    public URI getUrl() throws URISyntaxException {
-        return generateUrl(kakaoSocialLoginProperties.getAuthorizeUri());
+    public URI getUrl(String frontUrl) throws URISyntaxException {
+        return generateUrl(
+            frontUrl,
+            kakaoSocialLoginProperties.getAuthorizeUri()
+        );
     }
 
     @Override
-    public SocialLoginToken getToken(String authorizationCode) {
+    public SocialLoginToken getToken(
+        String authorizationCode,
+        String frontUrl
+    ) {
         return socialLoginPort.getToken(
             new SocialLoginTokenRequest(
                 GRANT_TYPE,
                 kakaoSocialLoginProperties.getClientId(),
-                kakaoSocialLoginProperties.getRedirectUri(),
+                frontUrl + kakaoSocialLoginProperties.getRedirectUri(),
                 authorizationCode
             )
         );
     }
 
-    private URI generateUrl(String socialLoginPath) throws URISyntaxException {
+    private URI generateUrl(
+        String frontUrl,
+        String socialLoginPath
+    ) throws URISyntaxException {
         return new URI(
             socialLoginPath +
                 QUERY_PARAMETER_PREFIX + "client_id=" + kakaoSocialLoginProperties.getClientId()
                 +
-                ENCODED_QUERY_PARAMETER_DELIMETER + "redirect_uri="
-                + kakaoSocialLoginProperties.getRedirectUri() +
-                ENCODED_QUERY_PARAMETER_DELIMETER + "response_type="
-                + kakaoSocialLoginProperties.getResponseType()
+                ENCODED_QUERY_PARAMETER_DELIMETER + "redirect_uri=" + frontUrl + kakaoSocialLoginProperties.getRedirectUri()
+                +
+                ENCODED_QUERY_PARAMETER_DELIMETER + "response_type=" + kakaoSocialLoginProperties.getResponseType()
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/user/service/util/strategy/SocialLoginStrategy.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/strategy/SocialLoginStrategy.java
@@ -7,9 +7,9 @@ import java.net.URISyntaxException;
 
 public interface SocialLoginStrategy {
 
-    URI getUrl() throws URISyntaxException;
+    URI getUrl(String frontUrl) throws URISyntaxException;
 
-    SocialLoginToken getToken(String authorizationCode);
+    SocialLoginToken getToken(String authorizationCode, String frontUrl);
 
     IdToken resolveIdToken(String idToken);
 

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -1,6 +1,7 @@
 package com.pikachu.purple.bootstrap.auth.api;
 
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
+import com.pikachu.purple.bootstrap.auth.dto.request.SocialLoginRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
@@ -25,7 +26,8 @@ public interface AuthApi {
     @PostMapping("/login-try/{provider}")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<SocialLoginTryResponse> socialLoginTry(
-        @PathVariable("provider")SocialLoginProvider provider
+        @PathVariable("provider")SocialLoginProvider provider,
+        @RequestBody SocialLoginRequest request
     ) throws URISyntaxException;
 
     @Operation(summary = "소셜 로그인")
@@ -33,7 +35,8 @@ public interface AuthApi {
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<SocialLoginResponse> socialLogin(
         @PathVariable("provider")SocialLoginProvider provider,
-        @RequestParam String code
+        @RequestParam String code,
+        @RequestBody SocialLoginRequest request
     );
 
     @Operation(summary = "Jwt Token Refresh API")

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase;
 import com.pikachu.purple.application.user.port.in.SocialLoginUseCase;
 import com.pikachu.purple.bootstrap.auth.api.AuthApi;
 import com.pikachu.purple.bootstrap.auth.dto.request.RefreshJwtTokenRequest;
+import com.pikachu.purple.bootstrap.auth.dto.request.SocialLoginRequest;
 import com.pikachu.purple.bootstrap.auth.dto.response.RefreshJwtTokenResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginResponse;
 import com.pikachu.purple.bootstrap.auth.dto.response.SocialLoginTryResponse;
@@ -24,10 +25,14 @@ public class AuthController implements AuthApi {
 
     @Override
     public SuccessResponse<SocialLoginTryResponse> socialLoginTry(
-        SocialLoginProvider socialLoginProvider)
-        throws URISyntaxException {
+        SocialLoginProvider socialLoginProvider,
+        SocialLoginRequest request
+    ) throws URISyntaxException {
         SocialLoginTryUseCase.Result result = socialLoginTryUseCase.invoke(
-            new SocialLoginTryUseCase.Command(socialLoginProvider)
+            new SocialLoginTryUseCase.Command(
+                socialLoginProvider,
+                request.frontUrl()
+            )
         );
 
         return SuccessResponse.of(
@@ -38,12 +43,14 @@ public class AuthController implements AuthApi {
     @Override
     public SuccessResponse<SocialLoginResponse> socialLogin(
         SocialLoginProvider socialLoginProvider,
-        String code
+        String code,
+        SocialLoginRequest request
     ) {
         SocialLoginUseCase.Result result = socialLoginUseCase.invoke(
             new SocialLoginUseCase.Command(
                 socialLoginProvider,
-                code
+                code,
+                request.frontUrl()
             )
         );
 

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/SocialLoginRequest.java
@@ -1,0 +1,3 @@
+package com.pikachu.purple.bootstrap.auth.dto.request;
+
+public record SocialLoginRequest(String frontUrl) {}

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/SocialLoginTryRequest.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/dto/request/SocialLoginTryRequest.java
@@ -1,6 +1,0 @@
-package com.pikachu.purple.bootstrap.auth.dto.request;
-
-import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
-
-public record SocialLoginTryRequest(SocialLoginProvider socialLoginProvider) {
-}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,7 +82,7 @@ auth:
     client-id: ${KAKAO_CLIENT_ID}
     response-type: code
     authorize-uri: https://kauth.kakao.com/oauth/authorize
-    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:3000/perpicks/auth/login/kakao}
+    redirect-uri: ${KAKAO_REDIRECT_URI:/perpicks/auth/login/kakao}
     jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
 
 uri:


### PR DESCRIPTION
### 진행상황
- 기존 카카오 로그인 로직은 프론트엔드의 요청 url(http://ip:port)에 따라 동적으로 리디렉션 url을 반환할 수 없는 구조
- 프론트엔드에게 직접 url을 받아 리디렉션 url을 생성 후 반환하는 로직으로 수정