### PR TITLE
[PURPLE-194] 어코드 기반 추천 향수 리스트 조회시 값이 존재하지 않을 때, 반환 형태 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -12,6 +12,7 @@ import com.pikachu.purple.application.user.port.in.useraccord.GetTopThreeUserAcc
 import com.pikachu.purple.domain.accord.Accord;
 import com.pikachu.purple.domain.perfume.Perfume;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,10 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
         GetTopThreeUserAccordsUseCase.Result result = getTopThreeUserAccordsUseCase.invoke();
 
         if (result.userAccords().isEmpty()) {
-            throw UserAccordNotFoundException;
+            return new Result(
+                Collections.emptyList(),
+                Collections.emptyList()
+            );
         }
 
         List<UserAccordDTO> userAccordDTOs = IntStream.range(0, 3)

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -1,7 +1,5 @@
 package com.pikachu.purple.application.perfume.service.application;
 
-import static com.pikachu.purple.bootstrap.common.exception.BusinessException.UserAccordNotFoundException;
-
 import com.pikachu.purple.application.perfume.common.dto.RecommendedPerfumeDTO;
 import com.pikachu.purple.application.perfume.common.dto.UserAccordDTO;
 import com.pikachu.purple.application.perfume.common.vo.PerfumeAccordMatchVO;


### PR DESCRIPTION
### 진행상황
- 어코드 기반 추천 향수 리스트 조회시 선호 어코드의 값이 존재하지 않으면, 404(선호하는 어코드가 없습니다.) -> 빈 리스트 형태로 수정했습니다.