### PR TITLE
[PURPLE-192] 회원 탈퇴 API

### DIFF
--- a/src/main/java/com/pikachu/purple/application/user/port/in/user/DeleteUserUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/user/DeleteUserUseCase.java
@@ -1,0 +1,9 @@
+package com.pikachu.purple.application.user.port.in.user;
+
+public interface DeleteUserUseCase {
+
+    Result invoke();
+
+    record Result(String clientUrl) {}
+
+}

--- a/src/main/java/com/pikachu/purple/application/user/port/out/UserTokenRepository.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/out/UserTokenRepository.java
@@ -16,7 +16,7 @@ public interface UserTokenRepository {
         Long expirationSeconds
     );
 
-    Optional<String> findAccessTokenByUserId(
+    void findAccessTokenByUserId(
         Long userId
     );
 

--- a/src/main/java/com/pikachu/purple/application/user/service/application/user/DeleteUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/user/DeleteUserApplicationService.java
@@ -1,0 +1,34 @@
+package com.pikachu.purple.application.user.service.application.user;
+
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
+import com.pikachu.purple.application.user.port.in.user.DeleteUserUseCase;
+import com.pikachu.purple.application.user.service.domain.UserDomainService;
+import com.pikachu.purple.application.user.service.util.UserTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteUserApplicationService implements DeleteUserUseCase {
+
+    private final UserTokenService userTokenService;
+    private final UserDomainService userDomainService;
+
+    @Value("${uri.client}")
+    private String clientUrl;
+
+    @Transactional
+    @Override
+    public Result invoke() {
+        Long userId = getCurrentUserAuthentication().userId();
+
+        userTokenService.deleteAllToken(userId);
+        userDomainService.delete(userId);
+
+        return new Result(clientUrl);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/UserDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/UserDomainService.java
@@ -29,4 +29,6 @@ public interface UserDomainService {
 
     User findById(Long userId);
 
+    void delete(Long userId);
+
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/domain/impl/UserDomainServiceImpl.java
@@ -14,7 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class UserDomainServiceImpl implements UserDomainService {
 
-    private static final String IMAGE_DEFAULT = "";
+    private static final String NICKNAME_ANONYMIZATION = "익명의 사용자";
+    private static final String STRING_DEFAULT = "";
     private final UserRepository userRepository;
     private final ImageUrlS3Uploader imageUrlS3Uploader;
 
@@ -91,7 +92,7 @@ public class UserDomainServiceImpl implements UserDomainService {
     }
 
     private String changeImage(Long userId, MultipartFile picture) {
-        if (picture == null || picture.isEmpty()) return IMAGE_DEFAULT;
+        if (picture == null || picture.isEmpty()) return STRING_DEFAULT;
         return imageUrlS3Uploader.upload(
             userId,
             picture
@@ -118,6 +119,19 @@ public class UserDomainServiceImpl implements UserDomainService {
     @Override
     public User findById(Long userId) {
         return userRepository.findById(userId);
+    }
+
+    @Override
+    public void delete(Long userId) {
+        User user = userRepository.findById(userId);
+
+        deleteExistingImage(user);
+
+        user.updateEmail(STRING_DEFAULT);
+        user.updateNickname(NICKNAME_ANONYMIZATION);
+        user.updateImageUrl(STRING_DEFAULT);
+
+        userRepository.update(user);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/util/impl/UserTokenServiceImpl.java
@@ -1,7 +1,5 @@
 package com.pikachu.purple.application.user.service.util.impl;
 
-import static com.pikachu.purple.bootstrap.common.exception.BusinessException.AccessTokenExpiredException;
-
 import com.pikachu.purple.application.common.properties.JwtTokenProperties;
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
 import com.pikachu.purple.application.user.service.util.UserTokenService;
@@ -56,7 +54,7 @@ public class UserTokenServiceImpl implements UserTokenService {
         );
         String email = jwtClaims.getCustomClaims().get("email").toString().replace("\"", "");
 
-        userTokenRepository.findAccessTokenByUserId(userId).orElseThrow(() -> AccessTokenExpiredException);
+        userTokenRepository.findAccessTokenByUserId(userId);
 
         return new AccessToken(
             userId,

--- a/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/common/exception/ErrorCode.java
@@ -87,7 +87,6 @@ public enum ErrorCode {
         "J005",
         "리프레시 토큰을 찾을 수 없습니다."
     ),
-
     NOT_VALID_LOGIN_ID_TOKEN(
         400,
         "J006",

--- a/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
@@ -141,5 +141,10 @@ public interface UserApi {
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUserAndSortType(@RequestParam("sort-type") String sortType);
 
+    @Secured
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/my/withdraw")
+    @ResponseStatus(HttpStatus.OK)
+    SuccessResponse<String> withdraw();
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.pikachu.purple.application.history.port.in.visithistory.DeleteVisitHi
 import com.pikachu.purple.application.history.port.in.visithistory.GetVisitHistoriesUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetReviewByPerfumeIdAndUserUseCase;
 import com.pikachu.purple.application.review.port.in.starrating.GetReviewsByUserAndSortTypeUseCase;
+import com.pikachu.purple.application.user.port.in.user.DeleteUserUseCase;
 import com.pikachu.purple.application.user.port.in.user.GetUserProfileByUserUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetTopThreeReviewedBrandsUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetUserReviewCountsUseCase;
@@ -43,6 +44,7 @@ public class UserController implements UserApi {
     private final GetPolarizedUserAccordsByUserUseCase getPolarizedUserAccordsByUserUseCase;
     private final GetUserProfileByUserUseCase getUserProfileByUserUseCase;
     private final GetReviewsByUserAndSortTypeUseCase getReviewsByUserAndSortTypeUseCase;
+    private final DeleteUserUseCase deleteUserUseCase;
 
     @Override
     public SuccessResponse<GetUserProfileResponse> updateProfile(
@@ -155,6 +157,13 @@ public class UserController implements UserApi {
         return SuccessResponse.of(
             new GetReviewsByUserAndSortTypeResponse(result.reviewWithPerfumeDTOs())
         );
+    }
+
+    @Override
+    public SuccessResponse<String> withdraw() {
+        DeleteUserUseCase.Result result = deleteUserUseCase.invoke();
+
+        return SuccessResponse.of(result.clientUrl());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/domain/user/User.java
+++ b/src/main/java/com/pikachu/purple/domain/user/User.java
@@ -35,6 +35,10 @@ public class User {
         this.imageUrl = imageUrl;
     }
 
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
     public User(Long id, String nickname, String email, String imageUrl,
         SocialLoginProvider socialLoginProvider) {
         this.id = id;

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/user/entity/UserJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/user/entity/UserJpaEntity.java
@@ -41,6 +41,7 @@ public class UserJpaEntity extends BaseEntity {
     private SocialLoginProvider socialLoginProvider;
 
     public void update(User user) {
+        this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.imageUrl = user.getImageUrl();
     }

--- a/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserTokenRedisAdapter.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/redis/user/adapter/UserTokenRedisAdapter.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.infrastructure.redis.user.adapter;
 
+import static com.pikachu.purple.bootstrap.common.exception.BusinessException.AccessTokenExpiredException;
+
 import com.pikachu.purple.application.user.port.out.UserTokenRepository;
 import com.pikachu.purple.infrastructure.redis.user.entity.UserAccessTokenRedisHash;
 import com.pikachu.purple.infrastructure.redis.user.entity.UserRefreshTokenRedisHash;
@@ -47,13 +49,8 @@ public class UserTokenRedisAdapter implements UserTokenRepository {
     }
 
     @Override
-    public Optional<String> findAccessTokenByUserId(Long userId) {
-        Optional<UserAccessTokenRedisHash> userAccessTokenRedisHash = userAccessTokenRedisRepository.findById(
-            userId);
-
-        String accessToken = userAccessTokenRedisHash.get().getAccessToken();
-
-        return Optional.of(accessToken);
+    public void findAccessTokenByUserId(Long userId) {
+        userAccessTokenRedisRepository.findById(userId).orElseThrow(() -> AccessTokenExpiredException);
     }
 
     @Override


### PR DESCRIPTION
### 진행상황
- 회원 탈퇴 시 사용자 정보 변환
  - (임시) nickname -> 익명의 사용자
  - imageUrl -> ""
  - email -> ""

### 개선사항
- 퍼픽 사용자 default 이미지 적용
- accesstoken 만료 exception이 서버에서 404로 발생하지만, swagger에서는 500으로 보임