### PR TITLE
[PURPLE-200] 향수 상세 페이지 내 별점 조회 API 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewByUserDTO.java
+++ b/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewByUserDTO.java
@@ -40,4 +40,15 @@ public record ReviewByUserDTO(
         );
     }
 
+    public static ReviewByUserDTO empty() {
+        return new ReviewByUserDTO(
+            null,
+            null,
+            0,
+            null,
+            List.of(),
+            List.of()
+        );
+    }
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
@@ -33,31 +33,33 @@ public class GetReviewByPerfumeIdAndUserApplicationService implements
         );
 
         ReviewByUserDTO reviewByUserDTO;
-        if(review.getType() == ReviewType.SIMPLE) {
-            reviewByUserDTO = ReviewByUserDTO.from(review);
-        }
+        if (review != null) {
+            if (review.getType() == ReviewType.SIMPLE) {
+                reviewByUserDTO = ReviewByUserDTO.from(review);
+            } else {
+                List<ReviewEvaluationFieldDTO> reviewEvaluation = review.getEvaluation()
+                    .getFields(review.getId()).stream()
+                    .map(fieldType ->
+                        ReviewEvaluationFieldDTO.of(
+                            fieldType,
+                            review.getEvaluation().getOptions(review.getId(), fieldType).stream()
+                                .map(ReviewEvaluationOptionDTO::of)
+                                .toList()
+                        )
+                    ).toList();
 
-        else {
-            List<ReviewEvaluationFieldDTO> reviewEvaluation = review.getEvaluation()
-                .getFields(review.getId()).stream()
-                .map(fieldType ->
-                    ReviewEvaluationFieldDTO.of(
-                        fieldType,
-                        review.getEvaluation().getOptions(review.getId(), fieldType).stream()
-                            .map(ReviewEvaluationOptionDTO::of)
-                            .toList()
-                    )
-                ).toList();
+                List<String> moodNames = review.getMoods().stream()
+                    .map(Mood::getName)
+                    .toList();
 
-            List<String> moodNames = review.getMoods().stream()
-                .map(Mood::getName)
-                .toList();
-
-            reviewByUserDTO = ReviewByUserDTO.of(
-                review,
-                reviewEvaluation,
-                moodNames
-            );
+                reviewByUserDTO = ReviewByUserDTO.of(
+                    review,
+                    reviewEvaluation,
+                    moodNames
+                );
+            }
+        } else {
+            reviewByUserDTO = ReviewByUserDTO.empty();
         }
 
         return new Result(reviewByUserDTO);

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
@@ -220,12 +220,12 @@ public class ReviewJpaAdaptor implements ReviewRepository {
         Long userId,
         Long perfumeId
     ) {
-        ReviewJpaEntity reviewJpaEntity = reviewJpaRepository.findByUserIdAndPerfumeId(
+        return reviewJpaRepository.findByUserIdAndPerfumeId(
             userId,
             perfumeId
-        ).orElseThrow(() -> ReviewNotFoundException);
-
-        return ReviewJpaEntity.toDomainWithEvaluationAndMoods(reviewJpaEntity);
+        )
+            .map(ReviewJpaEntity::toDomainWithEvaluationAndMoods)
+            .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
### 진행상황
- 기존 별점 조회를 할 때 평가한 향수가 없다면 404 exception을 반환했습니다.
- 프론트의 요청으로 반환하는 값을 기본값으로 수정했습니다.