### PR TITLE
[PURPLE-205] 최근 검색 기록 저장 API로 분리

### DIFF
--- a/src/main/java/com/pikachu/purple/bootstrap/search/controller/SearchController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/search/controller/SearchController.java
@@ -1,11 +1,9 @@
 package com.pikachu.purple.bootstrap.search.controller;
 
-import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByKeywordUseCase;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumesResponse;
 import com.pikachu.purple.bootstrap.search.api.SearchApi;
-import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,18 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController implements SearchApi {
 
     private final GetPerfumesByKeywordUseCase getPerfumesByKeywordUseCase;
-    private final CreateSearchHistoryUseCase createSearchHistoryUseCase;
 
     @Override
     public SuccessResponse<GetPerfumesResponse> findAllPerfumesByKeyword(String keyword) {
         GetPerfumesByKeywordUseCase.Result result = getPerfumesByKeywordUseCase.invoke(
             new GetPerfumesByKeywordUseCase.Command(keyword));
-
-        Instant searchAt = Instant.now();
-        createSearchHistoryUseCase.invoke(
-            keyword,
-            searchAt
-        );
 
         return SuccessResponse.of(new GetPerfumesResponse(result.perfumeDTOs()));
     }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
@@ -79,6 +79,12 @@ public interface UserApi {
     SuccessResponse<GetTopThreeReviewedBrandsResponse> findTopThreeReviewedBrands();
 
     @Secured
+    @Operation(summary = "최근 검색 기록 저장")
+    @PostMapping("/my/search-histories")
+    @ResponseStatus(HttpStatus.OK)
+    void createSearchHistory(@RequestParam String keyword);
+
+    @Secured
     @Operation(summary = "최근 검색 기록 전체 조회")
     @GetMapping("/my/search-histories")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.pikachu.purple.bootstrap.user.controller;
 
+import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.DeleteSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.GetSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.visithistory.CreateVisitHistoryUseCase;
@@ -37,6 +38,7 @@ public class UserController implements UserApi {
     private final DeleteSearchHistoriesUseCase deleteSearchHistoriesUseCase;
     private final CreateVisitHistoryUseCase createVisitHistoryUseCase;
     private final GetVisitHistoriesUseCase getVisitHistoriesUseCase;
+    private final CreateSearchHistoryUseCase createSearchHistoryUseCase;
     private final GetUserReviewCountsUseCase getUserReviewCountsUseCase;
     private final DeleteVisitHistoriesUseCase deleteVisitHistoriesUseCase;
     private final GetTopThreeReviewedBrandsUseCase getTopThreeReviewedBrandsUseCase;
@@ -85,6 +87,15 @@ public class UserController implements UserApi {
 
         return SuccessResponse.of(
             new GetTopThreeReviewedBrandsResponse(result.reviewedBrandDTOs()));
+    }
+
+    @Override
+    public void createSearchHistory(String keyword) {
+        Instant searchAt = Instant.now();
+        createSearchHistoryUseCase.invoke(
+            keyword,
+            searchAt
+        );
     }
 
     @Override


### PR DESCRIPTION
### 진행상황
- 검색 API에서 사용자가 단어를 입력할때 마다 요청을 보내기 때문에 의도치 않은 검색 기록이 많이 남음
  - 한 검색에 대해 -> ex) 데이지, 데이지 러브, 데이지 러브 오 ....
- 기존 검색 API에 최근 검색 저장 로직이 포함
- 최근 검색 저장 로직을 API로 분리
- 최종적으로 검색한 결과에서 향수 상세 페이지로 넘어가거나, 키보드 창에서 입력 혹은 검색 버튼을 눌렀을 때만 최근 검색 기록을 저장하도록 변경