### PR TITLE
[PURPLE-209] 향수 상세 페이지 내 '평가하기' 별점 조회 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewByUserDTO.java
+++ b/src/main/java/com/pikachu/purple/application/review/common/dto/ReviewByUserDTO.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.application.review.common.dto;
 
 import com.pikachu.purple.application.util.IdUtil;
 import com.pikachu.purple.domain.review.Review;
+import com.pikachu.purple.domain.review.StarRating;
 import com.pikachu.purple.domain.review.enums.ReviewType;
 import java.util.List;
 
@@ -20,6 +21,17 @@ public record ReviewByUserDTO(
             review.getType(),
             review.getStarRating().getScore(),
             review.getContent(),
+            null,
+            null
+        );
+    }
+
+    public static ReviewByUserDTO from(StarRating starRating) {
+        return new ReviewByUserDTO(
+            null,
+            ReviewType.ONBOARDING,
+            starRating.getScore(),
+            null,
             null,
             null
         );

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
@@ -7,8 +7,10 @@ import com.pikachu.purple.application.review.common.dto.ReviewEvaluationFieldDTO
 import com.pikachu.purple.application.review.common.dto.ReviewEvaluationOptionDTO;
 import com.pikachu.purple.application.review.port.in.review.GetReviewByPerfumeIdAndUserUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
+import com.pikachu.purple.application.review.service.domain.StarRatingDomainService;
 import com.pikachu.purple.domain.review.Mood;
 import com.pikachu.purple.domain.review.Review;
+import com.pikachu.purple.domain.review.StarRating;
 import com.pikachu.purple.domain.review.enums.ReviewType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class GetReviewByPerfumeIdAndUserApplicationService implements
     GetReviewByPerfumeIdAndUserUseCase {
 
     private final ReviewDomainService reviewDomainService;
+    private final StarRatingDomainService starRatingDomainService;
 
     @Transactional
     @Override
@@ -32,8 +35,13 @@ public class GetReviewByPerfumeIdAndUserApplicationService implements
             command.perfumeId()
         );
 
-        ReviewByUserDTO reviewByUserDTO;
-        if (review != null) {
+        StarRating starRating = starRatingDomainService.findByUserIdAndPerfumeId(
+            userId,
+            command.perfumeId()
+        );
+
+        ReviewByUserDTO reviewByUserDTO = null;
+        if(review != null) {
             if (review.getType() == ReviewType.SIMPLE) {
                 reviewByUserDTO = ReviewByUserDTO.from(review);
             } else {
@@ -58,7 +66,13 @@ public class GetReviewByPerfumeIdAndUserApplicationService implements
                     moodNames
                 );
             }
-        } else {
+        }
+
+        if(review == null && starRating != null) {
+            reviewByUserDTO = ReviewByUserDTO.from(starRating);
+        }
+
+        if(review == null && starRating == null) {
             reviewByUserDTO = ReviewByUserDTO.empty();
         }
 

--- a/src/main/java/com/pikachu/purple/domain/review/enums/ReviewType.java
+++ b/src/main/java/com/pikachu/purple/domain/review/enums/ReviewType.java
@@ -3,6 +3,7 @@ package com.pikachu.purple.domain.review.enums;
 public enum ReviewType {
 
     SIMPLE,
-    DETAIL
+    DETAIL,
+    ONBOARDING
 
 }


### PR DESCRIPTION
### 진행상황
- 향수 상세 페이지 내 '평가하기' 별점 조회에서 온보딩때 평가한 향수도 조회할 수 있도록 변경했습니다.
- 기존 ReviewType에 ONBOARDING으로 반환됩니다.