### PR TITLE
[PURPLE-218] 향수 평가 집계 방식 수정

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsDetailWithEvaluationUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsDetailWithEvaluationUseCase.java
@@ -3,12 +3,9 @@ package com.pikachu.purple.application.review.port.in.review;
 import com.pikachu.purple.domain.review.Review;
 import java.util.List;
 
-public interface GetReviewsDetailWithEvaluationByUpdatedDateUseCase {
+public interface GetReviewsDetailWithEvaluationUseCase {
 
-
-    Result invoke(Command command);
-
-    record Command(String updatedDate) {}
+    Result invoke();
 
     record Result(List<Review> reviews) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/reviewevaluation/GetReviewEvaluationUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/reviewevaluation/GetReviewEvaluationUseCase.java
@@ -5,9 +5,9 @@ import com.pikachu.purple.domain.review.ReviewEvaluation;
 
 public interface GetReviewEvaluationUseCase {
 
-    Result invoke(Command command);
+    Result invoke();
 
-    record Command(Long reviewId) {}
+    Result invoke(Long reviewId);
 
     record Result(ReviewEvaluation reviewEvaluation) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/out/ReviewEvaluationRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/ReviewEvaluationRepository.java
@@ -4,16 +4,14 @@ import com.pikachu.purple.domain.review.ReviewEvaluation;
 
 public interface ReviewEvaluationRepository {
 
-    void create(
-        ReviewEvaluation reviewEvaluation
-    );
+    void createAll(ReviewEvaluation reviewEvaluation);
 
-    ReviewEvaluation find(Long reviewId);
+    ReviewEvaluation findAll();
+
+    ReviewEvaluation findAll(Long reviewId);
 
     void deleteAll(Long reviewId);
 
-    void update(
-        ReviewEvaluation reviewEvaluation
-    );
+    void updateAll(ReviewEvaluation reviewEvaluation);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/out/ReviewRepository.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/out/ReviewRepository.java
@@ -22,7 +22,7 @@ public interface ReviewRepository {
 
     List<Review> findAllWithPerfumeAndReviewEvaluationAndMoodAndIsComplainedOrderByScoreAsc(Long userId, Long perfumeId);
 
-    List<Review> findAllWithEvaluation(ReviewType reviewType, String updatedDate);
+    List<Review> findAllWithEvaluation(ReviewType reviewType);
 
     void update(Long reviewId, String content, ReviewType reviewType);
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
@@ -33,7 +33,7 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
         );
 
         if(review.getType() == ReviewType.DETAIL) {
-            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.find(
+            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(
                 command.reviewId());
 
             reviewEvaluationDomainService.deleteAll(command.reviewId());

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsDetailWithEvaluationApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsDetailWithEvaluationApplicationService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.review.service.application.review;
 
-import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationByUpdatedDateUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.enums.ReviewType;
@@ -11,19 +11,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class GetReviewsDetailWithEvaluationByUpdatedDateApplicationService implements
-    GetReviewsDetailWithEvaluationByUpdatedDateUseCase {
+public class GetReviewsDetailWithEvaluationApplicationService implements
+    GetReviewsDetailWithEvaluationUseCase {
 
     private final ReviewDomainService reviewDomainService;
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
-
-        List<Review> reviews = reviewDomainService.findAllWithEvaluation(
-            ReviewType.DETAIL,
-            command.updatedDate()
-        );
+    public Result invoke() {
+        List<Review> reviews = reviewDomainService.findAllWithEvaluation(ReviewType.DETAIL);
 
         return new Result(reviews);
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
@@ -46,7 +46,7 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
         }
 
         else{
-            ReviewEvaluation beforeReviewEvaluation = reviewEvaluationDomainService.find(
+            ReviewEvaluation beforeReviewEvaluation = reviewEvaluationDomainService.findAll(
                 command.reviewId());
 
             decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
@@ -59,7 +59,7 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
                 command.reviewId(),
                 command.evaluationFieldVOs()
             );
-            reviewEvaluationDomainService.update(
+            reviewEvaluationDomainService.updateAll(
                 afterReviewEvaluation
             );
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
@@ -27,7 +27,7 @@ public class UpdateReviewSimpleApplicationService implements UpdateReviewSimpleU
         Review review = reviewDomainService.findWithPerfume(command.reviewId());
 
         if(review.getType() == ReviewType.DETAIL) {
-            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.find(command.reviewId());
+            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(command.reviewId());
             reviewEvaluationDomainService.deleteAll(command.reviewId());
             decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
                     review.getPerfume().getId(),

--- a/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/CreateReviewEvaluationApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/CreateReviewEvaluationApplicationService.java
@@ -25,7 +25,7 @@ public class CreateReviewEvaluationApplicationService implements CreateReviewEva
             command.evaluationFieldVOs()
         );
 
-        reviewEvaluationDomainService.create(reviewEvaluation);
+        reviewEvaluationDomainService.createAll(reviewEvaluation);
 
         increaseEvaluationStatisticUseCase.invoke(
             new IncreaseEvaluationStatisticUseCase.Command(

--- a/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/GetReviewEvaluationApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/GetReviewEvaluationApplicationService.java
@@ -13,9 +13,15 @@ public class GetReviewEvaluationApplicationService implements GetReviewEvaluatio
     private final ReviewEvaluationDomainService reviewEvaluationDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.find(
-            command.reviewId());
+    public Result invoke() {
+        ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll();
+
+        return new Result(reviewEvaluation);
+    }
+
+    @Override
+    public Result invoke(Long reviewId) {
+        ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(reviewId);
 
         return new Result(reviewEvaluation);
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewDomainService.java
@@ -47,10 +47,7 @@ public interface ReviewDomainService {
 
     Review find(Long reviewId);
 
-    List<Review> findAllWithEvaluation(
-        ReviewType reviewType,
-        String updatedDate
-    );
+    List<Review> findAllWithEvaluation(ReviewType reviewType);
 
     void deleteReviewMoods(Long reviewId);
 

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewEvaluationDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/ReviewEvaluationDomainService.java
@@ -4,16 +4,14 @@ import com.pikachu.purple.domain.review.ReviewEvaluation;
 
 public interface ReviewEvaluationDomainService {
 
-    void create(
-        ReviewEvaluation reviewEvaluation
-    );
+    void createAll(ReviewEvaluation reviewEvaluation);
 
-    ReviewEvaluation find(Long reviewId);
+    ReviewEvaluation findAll();
+
+    ReviewEvaluation findAll(Long reviewId);
 
     void deleteAll(Long reviewId);
 
-    void update(
-        ReviewEvaluation reviewEvaluation
-    );
+    void updateAll(ReviewEvaluation reviewEvaluation);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewDomainServiceImpl.java
@@ -107,14 +107,8 @@ public class ReviewDomainServiceImpl implements ReviewDomainService {
     }
 
     @Override
-    public List<Review> findAllWithEvaluation(
-        ReviewType reviewType,
-        String updatedDate
-    ) {
-        return reviewRepository.findAllWithEvaluation(
-            reviewType,
-            updatedDate
-        );
+    public List<Review> findAllWithEvaluation(ReviewType reviewType) {
+        return reviewRepository.findAllWithEvaluation(reviewType);
     }
 
     @Override

--- a/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewEvaluationDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/domain/impl/ReviewEvaluationDomainServiceImpl.java
@@ -14,17 +14,18 @@ public class ReviewEvaluationDomainServiceImpl implements ReviewEvaluationDomain
 
 
     @Override
-    public void create(
-        ReviewEvaluation reviewEvaluation
-    ) {
-        reviewEvaluationRepository.create(
-            reviewEvaluation
-        );
+    public void createAll(ReviewEvaluation reviewEvaluation) {
+        reviewEvaluationRepository.createAll(reviewEvaluation);
     }
 
     @Override
-    public ReviewEvaluation find(Long reviewId) {
-        return reviewEvaluationRepository.find(reviewId);
+    public ReviewEvaluation findAll() {
+        return reviewEvaluationRepository.findAll();
+    }
+
+    @Override
+    public ReviewEvaluation findAll(Long reviewId) {
+        return reviewEvaluationRepository.findAll(reviewId);
     }
 
     @Override
@@ -33,12 +34,8 @@ public class ReviewEvaluationDomainServiceImpl implements ReviewEvaluationDomain
     }
 
     @Override
-    public void update(
-        ReviewEvaluation reviewEvaluation
-    ) {
-       reviewEvaluationRepository.update(
-           reviewEvaluation
-       );
+    public void updateAll(ReviewEvaluation reviewEvaluation) {
+       reviewEvaluationRepository.updateAll(reviewEvaluation);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/RecountEvaluationStatisticsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/RecountEvaluationStatisticsUseCase.java
@@ -1,0 +1,7 @@
+package com.pikachu.purple.application.statistic.port.in.evaluationstatistic;
+
+public interface RecountEvaluationStatisticsUseCase {
+
+    void invoke();
+
+}

--- a/src/main/java/com/pikachu/purple/application/statistic/port/out/EvaluationStatisticRepository.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/out/EvaluationStatisticRepository.java
@@ -6,10 +6,7 @@ import com.pikachu.purple.domain.statistic.EvaluationStatistic;
 
 public interface EvaluationStatisticRepository {
 
-    EvaluationStatistic findOrderByVotesDesc(
-        String statisticsDate,
-        Long perfumeId
-    );
+    EvaluationStatistic findOrderByVotesDesc(Long perfumeId);
 
     void increaseVotes(
         Long perfumeId,
@@ -23,11 +20,8 @@ public interface EvaluationStatisticRepository {
         EvaluationOptionType option
     );
 
-    EvaluationStatistic find(String statisticsDate);
+    EvaluationStatistic findAll();
 
-    void update(
-        String statisticsDate,
-        EvaluationStatistic evaluationStatistic
-    );
+    void updateAll(EvaluationStatistic evaluationStatistic);
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/scheduler/EvaluationStatisticScheduler.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/scheduler/EvaluationStatisticScheduler.java
@@ -1,14 +1,6 @@
 package com.pikachu.purple.application.statistic.scheduler;
 
-import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumeIdsUseCase;
-import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationByUpdatedDateUseCase;
-import com.pikachu.purple.application.statistic.service.domain.EvaluationStatisticDomainService;
-import com.pikachu.purple.domain.evaluation.enums.EvaluationFieldType;
-import com.pikachu.purple.domain.review.Review;
-import com.pikachu.purple.domain.statistic.EvaluationStatistic;
-import com.pikachu.purple.util.DateUtil;
-import java.util.Arrays;
-import java.util.List;
+import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.RecountEvaluationStatisticsUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -17,87 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class EvaluationStatisticScheduler {
-    private final GetPerfumeIdsUseCase getPerfumeIdsUseCase;
-    private final EvaluationStatisticDomainService evaluationStatisticDomainService;
-    private final GetReviewsDetailWithEvaluationByUpdatedDateUseCase getReviewsDetailWithEvaluationByUpdatedDateUseCase;
+    private final RecountEvaluationStatisticsUseCase recountEvaluationStatisticsUseCase;
 
     @Transactional
     @Scheduled(cron = "${scheduler.daily-cron}")
     public void dailyRecountEvaluationStatistics() {
-        List<Long> perfumeIds = getPerfumeIdsUseCase.invoke().perfumeIds();
-
-        String theDayBeforeYesterday = DateUtil.theDayBeforeYesterday();
-        EvaluationStatistic theDayBeforeYesterdayEvaluationStatistic = evaluationStatisticDomainService
-            .findAll();
-
-        String yesterday = DateUtil.yesterday();
-        List<Review> yesterdayReviews =
-            getReviewsDetailWithEvaluationByUpdatedDateUseCase.invoke(
-                new GetReviewsDetailWithEvaluationByUpdatedDateUseCase.Command(yesterday)
-            ).reviews();
-        EvaluationStatistic yesterdayEvaluationStatistic = sum(yesterdayReviews);
-
-        EvaluationStatistic evaluationStatistic = calculateVotes(
-            perfumeIds,
-            theDayBeforeYesterdayEvaluationStatistic,
-            yesterdayEvaluationStatistic
-        );
-
-        evaluationStatisticDomainService.updateAll(evaluationStatistic);
-
-    }
-
-    private EvaluationStatistic sum(List<Review> reviews) {
-        EvaluationStatistic evaluationStatistic = new EvaluationStatistic();
-
-        reviews.forEach(
-            review -> review.getEvaluation().getFields(review.getId()).forEach(
-                fieldType -> review.getEvaluation().getOptions(review.getId(), fieldType).forEach(
-                    optionType -> evaluationStatistic.increase(
-                        review.getPerfume().getId(),
-                        fieldType,
-                        optionType
-                    )
-                )
-            )
-        );
-
-        return evaluationStatistic;
-    }
-
-    private EvaluationStatistic calculateVotes(
-        List<Long> perfumeIds,
-        EvaluationStatistic theDayBeforeYesterdayEvaluationStatistic,
-        EvaluationStatistic yesterdayEvaluationStatistic
-    ) {
-        EvaluationStatistic evaluationStatistic = new EvaluationStatistic();
-        perfumeIds.forEach(
-            perfumeId -> Arrays.stream(EvaluationFieldType.values()).forEach(
-                field -> field.getEvaluationOptionTypes().forEach(
-                    option -> {
-                        int theDayBeforeYesterdayVotes = theDayBeforeYesterdayEvaluationStatistic.getVotes(
-                            perfumeId,
-                            field,
-                            option
-                        );
-                        int yesterdayVotes = yesterdayEvaluationStatistic.getVotes(
-                            perfumeId,
-                            field,
-                            option
-                        );
-
-                        evaluationStatistic.set(
-                            perfumeId,
-                            field,
-                            option,
-                            theDayBeforeYesterdayVotes + yesterdayVotes
-                        );
-                    }
-                )
-            )
-        );
-
-        return evaluationStatistic;
+        recountEvaluationStatisticsUseCase.invoke();
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/scheduler/EvaluationStatisticScheduler.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/scheduler/EvaluationStatisticScheduler.java
@@ -28,7 +28,7 @@ public class EvaluationStatisticScheduler {
 
         String theDayBeforeYesterday = DateUtil.theDayBeforeYesterday();
         EvaluationStatistic theDayBeforeYesterdayEvaluationStatistic = evaluationStatisticDomainService
-            .find(theDayBeforeYesterday);
+            .findAll();
 
         String yesterday = DateUtil.yesterday();
         List<Review> yesterdayReviews =
@@ -43,10 +43,7 @@ public class EvaluationStatisticScheduler {
             yesterdayEvaluationStatistic
         );
 
-        evaluationStatisticDomainService.update(
-            yesterday,
-            evaluationStatistic
-        );
+        evaluationStatisticDomainService.updateAll(evaluationStatistic);
 
     }
 

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
@@ -28,9 +28,7 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
     public Result invoke(Command command) {
         String yesterday = DateUtil.yesterday();
         EvaluationStatistic evaluationStatistic = evaluationStatisticDomainService.findOrderByVotesDesc(
-            yesterday,
-            command.perfumeId()
-        );
+            command.perfumeId());
 
         List<EvaluationFieldDTO<EvaluationOptionStatisticDTO>> evaluationFieldDTOs = new ArrayList<>();
         for (EvaluationFieldType evaluationField : evaluationStatistic.getFields(

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
@@ -26,7 +26,6 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
 
     @Override
     public Result invoke(Command command) {
-        String yesterday = DateUtil.yesterday();
         EvaluationStatistic evaluationStatistic = evaluationStatisticDomainService.findOrderByVotesDesc(
             command.perfumeId());
 

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
@@ -10,7 +10,6 @@ import com.pikachu.purple.domain.evaluation.enums.EvaluationFieldType;
 import com.pikachu.purple.domain.evaluation.enums.EvaluationOptionType;
 import com.pikachu.purple.domain.statistic.EvaluationStatistic;
 import com.pikachu.purple.domain.statistic.StarRatingStatistic;
-import com.pikachu.purple.util.DateUtil;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/RecountEvaluationStatisticsApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/RecountEvaluationStatisticsApplicationService.java
@@ -1,0 +1,47 @@
+package com.pikachu.purple.application.statistic.service.application.evaluationstatistic;
+
+import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumeIdsUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationUseCase;
+import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.RecountEvaluationStatisticsUseCase;
+import com.pikachu.purple.application.statistic.service.domain.EvaluationStatisticDomainService;
+import com.pikachu.purple.domain.review.Review;
+import com.pikachu.purple.domain.statistic.EvaluationStatistic;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecountEvaluationStatisticsApplicationService implements
+    RecountEvaluationStatisticsUseCase {
+
+    private final EvaluationStatisticDomainService evaluationStatisticDomainService;
+    private final GetReviewsDetailWithEvaluationUseCase getReviewsDetailWithEvaluationUseCase;
+    private final GetPerfumeIdsUseCase getPerfumeIdsUseCase;
+
+    @Override
+    public void invoke() {
+        EvaluationStatistic evaluationStatistic = new EvaluationStatistic();
+
+        List<Long> perfumeIds = getPerfumeIdsUseCase.invoke().perfumeIds();
+        perfumeIds.forEach(evaluationStatistic::setDefault);
+
+        List<Review> reviews = getReviewsDetailWithEvaluationUseCase.invoke()
+            .reviews();
+
+        reviews.forEach(
+            review -> review.getEvaluation().getFields(review.getId()).forEach(
+                fieldType -> review.getEvaluation().getOptions(review.getId(), fieldType).forEach(
+                    optionType -> evaluationStatistic.increase(
+                        review.getPerfume().getId(),
+                        fieldType,
+                        optionType
+                    )
+                )
+            )
+        );
+
+        evaluationStatisticDomainService.updateAll(evaluationStatistic);
+    }
+
+}

--- a/src/main/java/com/pikachu/purple/application/statistic/service/domain/EvaluationStatisticDomainService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/domain/EvaluationStatisticDomainService.java
@@ -6,10 +6,7 @@ import com.pikachu.purple.domain.statistic.EvaluationStatistic;
 
 public interface EvaluationStatisticDomainService {
 
-    EvaluationStatistic findOrderByVotesDesc(
-        String statisticsDate,
-        Long perfumeId
-    );
+    EvaluationStatistic findOrderByVotesDesc(Long perfumeId);
 
     void increaseVotes(
         Long perfumeId,
@@ -23,11 +20,8 @@ public interface EvaluationStatisticDomainService {
         EvaluationOptionType option
     );
 
-    EvaluationStatistic find(String statisticsDate);
+    EvaluationStatistic findAll();
 
-    void update(
-        String statisticsDate,
-        EvaluationStatistic evaluationStatistic
-    );
+    void updateAll(EvaluationStatistic evaluationStatistic);
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/domain/impl/EvaluationStatisticDomainServiceImpl.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/domain/impl/EvaluationStatisticDomainServiceImpl.java
@@ -16,14 +16,8 @@ public class EvaluationStatisticDomainServiceImpl implements EvaluationStatistic
     private final EvaluationStatisticRepository evaluationStatisticRepository;
 
     @Override
-    public EvaluationStatistic findOrderByVotesDesc(
-        String statisticsDate,
-        Long perfumeId
-    ) {
-        return evaluationStatisticRepository.findOrderByVotesDesc(
-            statisticsDate,
-            perfumeId
-        );
+    public EvaluationStatistic findOrderByVotesDesc(Long perfumeId) {
+        return evaluationStatisticRepository.findOrderByVotesDesc(perfumeId);
     }
 
     @Override
@@ -61,19 +55,13 @@ public class EvaluationStatisticDomainServiceImpl implements EvaluationStatistic
     }
 
     @Override
-    public EvaluationStatistic find(String statisticsDate) {
-        return evaluationStatisticRepository.find(statisticsDate);
+    public EvaluationStatistic findAll() {
+        return evaluationStatisticRepository.findAll();
     }
 
     @Override
-    public void update(
-        String statisticsDate,
-        EvaluationStatistic evaluationStatistic
-    ) {
-        evaluationStatisticRepository.update(
-            statisticsDate,
-            evaluationStatistic
-        );
+    public void updateAll(EvaluationStatistic evaluationStatistic) {
+        evaluationStatisticRepository.updateAll(evaluationStatistic);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/admin/api/AdminApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/admin/api/AdminApi.java
@@ -33,7 +33,7 @@ public interface AdminApi {
     )
     @PostMapping("/evaluation-statistics")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    void countEvaluationStatistics();
+    void updateEvaluationStatistics();
 
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/admin/controller/AdminController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/admin/controller/AdminController.java
@@ -1,8 +1,8 @@
 package com.pikachu.purple.bootstrap.admin.controller;
 
 import com.pikachu.purple.application.perfume.port.in.perfume.RecalculatePerfumeAverageScoresUseCase;
+import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.RecountEvaluationStatisticsUseCase;
 import com.pikachu.purple.application.statistic.port.in.starratingstatistic.RecountStarRatingStatisticsUseCase;
-import com.pikachu.purple.application.statistic.scheduler.EvaluationStatisticScheduler;
 import com.pikachu.purple.bootstrap.admin.api.AdminApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +13,7 @@ public class AdminController implements AdminApi {
 
     private final RecountStarRatingStatisticsUseCase recountStarRatingStatisticsUseCase;
     private final RecalculatePerfumeAverageScoresUseCase recalculatePerfumeAverageScoresUseCase;
-    private final EvaluationStatisticScheduler evaluationStatisticScheduler;
+    private final RecountEvaluationStatisticsUseCase recountEvaluationStatisticsUseCase;
 
     @Override
     public void updateStarRatingStatistics() {
@@ -25,9 +25,8 @@ public class AdminController implements AdminApi {
         recalculatePerfumeAverageScoresUseCase.invoke();
     }
 
-    // TODO: Batch로 리팩토링 필요
     @Override
-    public void countEvaluationStatistics() {
-        evaluationStatisticScheduler.dailyRecountEvaluationStatistics();
+    public void updateEvaluationStatistics() {
+        recountEvaluationStatisticsUseCase.invoke();
     }
 }

--- a/src/main/java/com/pikachu/purple/domain/statistic/EvaluationStatistic.java
+++ b/src/main/java/com/pikachu/purple/domain/statistic/EvaluationStatistic.java
@@ -134,6 +134,14 @@ public class EvaluationStatistic {
         this.optionVotesMap.put(optionVotesKey, votes);
     }
 
+    public void setDefault(Long perfumeId) {
+        for (EvaluationFieldType field : EvaluationFieldType.values()) {
+            for (EvaluationOptionType option : EvaluationOptionType.values()) {
+                set(perfumeId, field, option, 0);
+            }
+        }
+    }
+
     public void increase(
         Long perfumeId,
         EvaluationFieldType field,

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewEvaluationJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewEvaluationJpaAdaptor.java
@@ -11,6 +11,7 @@ import com.pikachu.purple.infrastructure.persistence.review.repository.ReviewJpa
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,7 +22,7 @@ public class ReviewEvaluationJpaAdaptor implements ReviewEvaluationRepository {
     private final ReviewEvaluationJpaRepository reviewEvaluationJpaRepository;
 
     @Override
-    public void create(
+    public void createAll(
         ReviewEvaluation reviewEvaluation
     ) {
         List<ReviewEvaluationJpaEntity> reviewEvaluationJpaEntities = new ArrayList<>();
@@ -39,7 +40,21 @@ public class ReviewEvaluationJpaAdaptor implements ReviewEvaluationRepository {
     }
 
     @Override
-    public ReviewEvaluation find(Long reviewId) {
+    public ReviewEvaluation findAll() {
+        List<ReviewEvaluationJpaEntity> reviewEvaluationJpaEntities =
+            reviewEvaluationJpaRepository.findAll(
+                Sort.by(
+                    Sort.Order.asc("reviewJpaEntity.id"),
+                    Sort.Order.asc("fieldCode"),
+                    Sort.Order.asc("optionCode")
+                )
+            );
+
+        return ReviewEvaluationJpaEntity.toDomain(reviewEvaluationJpaEntities);
+    }
+
+    @Override
+    public ReviewEvaluation findAll(Long reviewId) {
         List<ReviewEvaluationJpaEntity> reviewEvaluationJpaEntities =
             reviewEvaluationJpaRepository.findByReviewId(reviewId);
 
@@ -55,11 +70,11 @@ public class ReviewEvaluationJpaAdaptor implements ReviewEvaluationRepository {
     }
 
     @Override
-    public void update(
+    public void updateAll(
         ReviewEvaluation reviewEvaluation
     ) {
         reviewEvaluation.getReviewIdSet().forEach(this::deleteAll);
-        create(reviewEvaluation);
+        createAll(reviewEvaluation);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/adaptor/ReviewJpaAdaptor.java
@@ -153,14 +153,8 @@ public class ReviewJpaAdaptor implements ReviewRepository {
     }
 
     @Override
-    public List<Review> findAllWithEvaluation(
-        ReviewType reviewType,
-        String updatedDate
-    ) {
-        List<ReviewJpaEntity> reviewJpaEntities = reviewJpaRepository.findAllByReviewTypeAndUpdateDate(
-            reviewType,
-            updatedDate
-        );
+    public List<Review> findAllWithEvaluation(ReviewType reviewType) {
+        List<ReviewJpaEntity> reviewJpaEntities = reviewJpaRepository.findAllByReviewType(reviewType);
 
         return reviewJpaEntities.stream()
             .map(ReviewJpaEntity::toDomainWithEvaluation)

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/review/repository/ReviewJpaRepository.java
@@ -35,12 +35,12 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long
         + "order by re.starRatingJpaEntity.score")
     List<ReviewJpaEntity> findAllByPerfumeIdOrderByScoreAsc(Long perfumeId);
 
-    @Query("select r "
-        + "from ReviewJpaEntity r "
-        + "where r.reviewType = :reviewType "
-        + " and FUNCTION('DATE_FORMAT', r.updatedAt, '%Y%m%d') = :updatedDate "
-        + "order by r.id asc")
-    List<ReviewJpaEntity> findAllByReviewTypeAndUpdateDate(ReviewType reviewType, String updatedDate);
+//    @Query("select r "
+//        + "from ReviewJpaEntity r "
+//        + "where r.reviewType = :reviewType "
+//        + " and FUNCTION('DATE_FORMAT', r.updatedAt, '%Y%m%d') = :updatedDate "
+//        + "order by r.id asc")
+    List<ReviewJpaEntity> findAllByReviewType(ReviewType reviewType);
 
     @Query("select r "
         + "from ReviewJpaEntity r "

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/EvaluationStatisticJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/EvaluationStatisticJpaEntity.java
@@ -32,14 +32,6 @@ import lombok.NoArgsConstructor;
 public class EvaluationStatisticJpaEntity extends BaseEntity {
 
     @Id
-    @Column(
-        name = "statistics_date",
-        columnDefinition = "char(8)",
-        nullable = false
-    )
-    private String statisticsDate;
-
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "perfume_id")
     private PerfumeJpaEntity perfumeJpaEntity;
@@ -80,7 +72,6 @@ public class EvaluationStatisticJpaEntity extends BaseEntity {
     }
 
     public static List<EvaluationStatisticJpaEntity> toJpaEntityList(
-        String statisticsDate,
         PerfumeJpaEntity perfumeJpaEntity,
         EvaluationStatistic evaluationStatistic
     ) {
@@ -99,7 +90,6 @@ public class EvaluationStatisticJpaEntity extends BaseEntity {
 
                     jpaEntities.add(
                         EvaluationStatisticJpaEntity.builder()
-                            .statisticsDate(statisticsDate)
                             .perfumeJpaEntity(perfumeJpaEntity)
                             .fieldCode(field.getCode())
                             .optionCode(option.getCode())

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/StarRatingStatisticJpaEntity.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/StarRatingStatisticJpaEntity.java
@@ -27,14 +27,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class StarRatingStatisticJpaEntity extends BaseEntity {
 
-//    @Id
-//    @Column(
-//        name = "statistics_date",
-//        columnDefinition = "char(8)",
-//        nullable = false
-//    )
-//    private String statisticsDate;
-
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "perfume_id")

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/id/EvaluationStatisticId.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/id/EvaluationStatisticId.java
@@ -7,8 +7,6 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 @NoArgsConstructor
 public class EvaluationStatisticId implements Serializable {
-
-    private String statisticsDate;
     private Long perfumeJpaEntity;
     private String fieldCode;
     private String optionCode;

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/id/StarRatingStatisticId.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/entity/id/StarRatingStatisticId.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StarRatingStatisticId implements Serializable {
 
-//    private String statisticsDate;
     private Long perfumeJpaEntity;
     private int score;
 

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/repository/EvaluationStatisticJpaRepository.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/repository/EvaluationStatisticJpaRepository.java
@@ -13,8 +13,7 @@ public interface EvaluationStatisticJpaRepository extends
 
   @Query("select es "
       + "from EvaluationStatisticJpaEntity es "
-      + "where es.statisticsDate = :#{#compositeKey.statisticsDate}"
-      + " and es.perfumeJpaEntity.id = :#{#compositeKey.perfumeId}"
+      + "where es.perfumeJpaEntity.id = :#{#compositeKey.perfumeId}"
       + " and es.fieldCode = :#{#compositeKey.fieldCode}"
       + " and es.optionCode = :#{#compositeKey.optionCode}")
   Optional<EvaluationStatisticJpaEntity> findByCompositeKey(
@@ -22,14 +21,8 @@ public interface EvaluationStatisticJpaRepository extends
 
   @Query("select es "
       + "from EvaluationStatisticJpaEntity es "
-      + "where es.statisticsDate = :today and es.perfumeJpaEntity.id = :perfumeId "
+      + "where es.perfumeJpaEntity.id = :perfumeId "
       + "order by es.fieldCode asc, es.votes desc")
-  List<EvaluationStatisticJpaEntity> findAllByStatisticsDateAndPerfumeIdOrderByVotesDesc(String today, Long perfumeId);
-
-  @Query("select es "
-      + "from EvaluationStatisticJpaEntity es "
-      + "where es.statisticsDate = :statisticsDate "
-      + "order by es.perfumeJpaEntity.id asc, es.fieldCode asc, es.optionCode asc")
-  List<EvaluationStatisticJpaEntity> findAllByStatisticsDate(String statisticsDate);
+  List<EvaluationStatisticJpaEntity> findAllByPerfumeIdOrderByVotesDesc(Long perfumeId);
 
 }

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/vo/EvaluationStatisticCompositeKey.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/vo/EvaluationStatisticCompositeKey.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record EvaluationStatisticCompositeKey(
-    String statisticsDate,
     Long perfumeId,
     String fieldCode,
     String optionCode

--- a/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/vo/StarRatingStatisticCompositeKey.java
+++ b/src/main/java/com/pikachu/purple/infrastructure/persistence/statistic/vo/StarRatingStatisticCompositeKey.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record StarRatingStatisticCompositeKey(
-//    String statisticsDate,
     Long perfumeId,
     int score
 ) {}

--- a/src/main/resources/db/migration/V20250106224523__drop_evaluation_statistic_statistics_date.sql
+++ b/src/main/resources/db/migration/V20250106224523__drop_evaluation_statistic_statistics_date.sql
@@ -1,0 +1,8 @@
+TRUNCATE TABLE evaluation_statistic;
+
+ALTER TABLE evaluation_statistic DROP PRIMARY KEY;
+
+ALTER TABLE evaluation_statistic
+    ADD CONSTRAINT pk_evaluation_statistic PRIMARY KEY (perfume_id, field_code, option_code);
+
+ALTER TABLE evaluation_statistic DROP COLUMN statistics_date;


### PR DESCRIPTION
## 진행 사항
- 향수 평가 집계 방식 변경
    - 별점통계(evaluation_statistic) 테이블의 통계일자(statistics_date) 컬럼 제거
    - 상세 리뷰 작성, 수정, 삭제 시 향수 평가 통계 테이블 갱신
    - 예상치 못한 이슈로 오류 발생 시, 긴급 처리를 위한 관리자용 향수 평가 집계 API 추가
        - `/perpicks/admin/evaluation-statistics`