### PR TITLE
[PURPLE-220] UseCase Command 제외

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/CreateVisitHistoryUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/CreateVisitHistoryUseCase.java
@@ -4,11 +4,9 @@ import java.time.Instant;
 
 public interface CreateVisitHistoryUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         Instant searchAt
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/CreateVisitHistoryApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/CreateVisitHistoryApplicationService.java
@@ -4,6 +4,7 @@ import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUse
 
 import com.pikachu.purple.application.history.port.in.visithistory.CreateVisitHistoryUseCase;
 import com.pikachu.purple.application.history.service.domain.VisitHistoryDomainService;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +17,16 @@ public class CreateVisitHistoryApplicationService implements CreateVisitHistoryU
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long perfumeId,
+        Instant searchAt
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
+
         visitHistoryDomainService.create(
             userId,
-            command.perfumeId(),
-            command.searchAt()
+            perfumeId,
+            searchAt
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
@@ -7,7 +7,6 @@ import com.pikachu.purple.application.history.port.in.visithistory.GetVisitHisto
 import com.pikachu.purple.application.history.service.domain.VisitHistoryDomainService;
 import com.pikachu.purple.application.perfume.common.dto.PerfumeDTO;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByIdsUseCase;
-import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumesByIdsUseCase.Command;
 import com.pikachu.purple.application.review.port.in.starrating.GetAverageScoreByPerfumeIdUseCase;
 import com.pikachu.purple.domain.history.VisitHistory;
 import com.pikachu.purple.domain.perfume.Perfume;
@@ -36,10 +35,10 @@ public class GetVisitHistoriesApplicationService implements GetVisitHistoriesUse
             .map(VisitHistory::getPerfumeId)
             .toList();
 
-        GetPerfumesByIdsUseCase.Result result = getPerfumesByIdsUseCase.invoke(new Command(perfumeIds));
+        GetPerfumesByIdsUseCase.Result result = getPerfumesByIdsUseCase.invoke(perfumeIds);
         for (Perfume perfume : result.perfumes()) {
             double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
-                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+                perfume.getId()).averageScore();
 
             perfume.setAverageScore(averageScore);
         }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/fragranticaevaluation/GetFragranticaEvaluationByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/fragranticaevaluation/GetFragranticaEvaluationByPerfumeIdUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetFragranticaEvaluationByPerfumeIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    Result invoke(Long perfumeId);
 
     record Result(List<FragranticaEvaluationFieldDTO> fragranticaEvaluation) {}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumeByIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumeByIdUseCase.java
@@ -4,9 +4,7 @@ import com.pikachu.purple.domain.perfume.Perfume;
 
 public interface GetPerfumeByIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    Result invoke(Long perfumeId);
 
     record Result(Perfume perfume) {}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumeDetailByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumeDetailByPerfumeIdUseCase.java
@@ -4,10 +4,8 @@ import com.pikachu.purple.application.perfume.common.dto.PerfumeDetailDTO;
 
 public interface GetPerfumeDetailByPerfumeIdUseCase {
 
-    GetPerfumeDetailByPerfumeIdUseCase.Result invoke(
-        GetPerfumeDetailByPerfumeIdUseCase.Command command);
+    Result invoke(Long perfumeId);
 
-    record Command(Long perfumeId) {}
 
     record Result(PerfumeDetailDTO perfumeDetail) {}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByBrandsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByBrandsUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetPerfumesByBrandsUseCase {
 
-    Result invoke(Command command);
-
-    record Command(List<String> brandNames) {}
+    Result invoke(List<String> brandNames);
 
     record Result(List<BrandPerfumesDTO> brandPerfumesDTOs) {}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByIdsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByIdsUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetPerfumesByIdsUseCase {
 
-    Result invoke(Command command);
-
-    record Command(List<Long> perfumeIds) {}
+    Result invoke(List<Long> perfumeIds);
 
     record Result(List<Perfume> perfumes) {}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByKeywordUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/GetPerfumesByKeywordUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetPerfumesByKeywordUseCase {
 
-    Result invoke(Command command);
-
-    record Command(String keyword){}
+    Result invoke(String keyword);
 
     record Result(List<PerfumeDTO> perfumeDTOs){}
 

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/RecalculatePerfumeAverageScoreUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/RecalculatePerfumeAverageScoreUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.perfume.port.in.perfume;
 
 public interface RecalculatePerfumeAverageScoreUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    void invoke(Long perfumeId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/RecalculatePerfumeAverageScoresUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/port/in/perfume/RecalculatePerfumeAverageScoresUseCase.java
@@ -6,7 +6,6 @@ public interface RecalculatePerfumeAverageScoresUseCase {
 
     void invoke();
 
-    void invoke(Command command);
+    void invoke(List<Long> perfumeIds);
 
-    record Command(List<Long> perfumeIds) {};
 }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/GetPerfumesAndUserAccordsByUserApplicationService.java
@@ -62,7 +62,7 @@ public class GetPerfumesAndUserAccordsByUserApplicationService implements
 
         for (Perfume perfume : perfumes) {
             double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
-                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+                perfume.getId()).averageScore();
             perfume.setAverageScore(averageScore);
         }
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/fragranticaevaluation/GetFragranticaEvaluationByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/fragranticaevaluation/GetFragranticaEvaluationByPerfumeIdApplicationService.java
@@ -22,10 +22,10 @@ public class GetFragranticaEvaluationByPerfumeIdApplicationService implements
     private final FragranticaEvaluationDomainService fragranticaEvaluationDomainService;
 
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(Long perfumeId) {
 
         FragranticaEvaluation fragranticaEvaluation = fragranticaEvaluationDomainService.findByPerfumeIdOrderByVotesDesc(
-            command.perfumeId());
+            perfumeId);
 
         List<FragranticaEvaluationFieldDTO> fragranticaEvaluationFieldDTOs = new ArrayList<>();
         for (EvaluationFieldType evaluationField : fragranticaEvaluation.getFieldSet()) {

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumeByIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumeByIdApplicationService.java
@@ -13,8 +13,8 @@ public class GetPerfumeByIdApplicationService implements GetPerfumeByIdUseCase {
     private final PerfumeDomainService perfumeDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        Perfume perfume = perfumeDomainService.findById(command.perfumeId());
+    public Result invoke(Long perfumeId) {
+        Perfume perfume = perfumeDomainService.findById(perfumeId);
 
         return new Result(perfume);
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumeDetailByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumeDetailByPerfumeIdApplicationService.java
@@ -26,9 +26,9 @@ public class GetPerfumeDetailByPerfumeIdApplicationService implements
     private static final int MAX_SIZE = 5;
 
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(Long perfumeId) {
 
-        Perfume perfume = perfumeDomainService.findById(command.perfumeId());
+        Perfume perfume = perfumeDomainService.findById(perfumeId);
 
         List<PerfumeAccord> perfumeAccords = perfumeAccordDomainService
             .findAllByPerfumeIdOrderByValueDesc(

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByBrandsApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByBrandsApplicationService.java
@@ -17,8 +17,8 @@ public class GetPerfumesByBrandsApplicationService implements GetPerfumesByBrand
     private final PerfumeDomainService perfumeDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        List<Perfume> perfumes = perfumeDomainService.findAllByBrandNames(command.brandNames());
+    public Result invoke(List<String> brandNames) {
+        List<Perfume> perfumes = perfumeDomainService.findAllByBrandNames(brandNames);
 
         Map<String, List<Perfume>> perfumesByBrand = perfumes.stream()
             .collect(Collectors.groupingBy(perfume -> perfume.getBrand().getKoreanName()));

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByIdsApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByIdsApplicationService.java
@@ -14,8 +14,8 @@ public class GetPerfumesByIdsApplicationService implements GetPerfumesByIdsUseCa
     private final PerfumeDomainService perfumeDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByIds(command.perfumeIds());
+    public Result invoke(List<Long> perfumeIds) {
+        List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByIds(perfumeIds);
 
         return new Result(perfumes);
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
@@ -19,8 +19,8 @@ public class GetPerfumesByKeywordApplicationService implements GetPerfumesByKeyw
 
     @Override
     @Transactional
-    public Result invoke(Command command) {
-        List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByKeyword(command.keyword());
+    public Result invoke(String keyword) {
+        List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByKeyword(keyword);
         for (Perfume perfume : perfumes) {
             double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
                 new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByKeywordApplicationService.java
@@ -23,7 +23,7 @@ public class GetPerfumesByKeywordApplicationService implements GetPerfumesByKeyw
         List<Perfume> perfumes = perfumeDomainService.findAllWithPerfumeAccordsByKeyword(keyword);
         for (Perfume perfume : perfumes) {
             double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
-                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+                perfume.getId()).averageScore();
             perfume.setAverageScore(averageScore);
         }
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByReviewCountApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/GetPerfumesByReviewCountApplicationService.java
@@ -27,7 +27,7 @@ public class GetPerfumesByReviewCountApplicationService implements
        List<Perfume> perfumes =  perfumeDomainService.findAllOrderByReviewCount(MAX_SIZE);
         for (Perfume perfume : perfumes) {
             double averageScore = getAverageScoreByPerfumeIdUseCase.invoke(
-                new GetAverageScoreByPerfumeIdUseCase.Command(perfume.getId())).averageScore();
+                perfume.getId()).averageScore();
             perfume.setAverageScore(averageScore);
         }
 

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/RecalculatePerfumeAverageScoreApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/RecalculatePerfumeAverageScoreApplicationService.java
@@ -19,9 +19,9 @@ public class RecalculatePerfumeAverageScoreApplicationService implements
 
     @Override
     @Transactional
-    public void invoke(Command command) {
+    public void invoke(Long perfumeId) {
         List<StarRatingStatistic> starRatingStatistics = getStarRatingStatisticsUseCase
-            .invoke(command.perfumeId())
+            .invoke(perfumeId)
             .starRatingStatistics();
 
         double totalScore = starRatingStatistics.stream()
@@ -34,7 +34,7 @@ public class RecalculatePerfumeAverageScoreApplicationService implements
 
         double averageScore = totalVotes > 0 ? totalScore / totalVotes : 0.0;
         perfumeDomainService.updateAverageScore(
-            command.perfumeId(),
+            perfumeId,
             averageScore
         );
     }

--- a/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/RecalculatePerfumeAverageScoresApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/perfume/service/application/perfume/RecalculatePerfumeAverageScoresApplicationService.java
@@ -35,9 +35,9 @@ public class RecalculatePerfumeAverageScoresApplicationService implements
 
     @Override
     @Transactional
-    public void invoke(Command command) {
+    public void invoke(List<Long> perfumeIds) {
         List<StarRatingStatistic> starRatingStatistics = getStarRatingStatisticsUseCase
-            .invoke(command.perfumeIds())
+            .invoke(perfumeIds)
             .starRatingStatistics();
 
         this.recalculatePerfumeAverageScores(starRatingStatistics);

--- a/src/main/java/com/pikachu/purple/application/review/port/in/SendComplaintUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/SendComplaintUseCase.java
@@ -4,8 +4,6 @@ import com.pikachu.purple.domain.review.Complaint;
 
 public interface SendComplaintUseCase {
 
-    void invoke(Command command);
-
-    record Command(Complaint complaint) {}
+    void invoke(Complaint complaint);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/complaint/CreateComplaintUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/complaint/CreateComplaintUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.complaint;
 
 public interface CreateComplaintUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/complaint/DeleteComplaintUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/complaint/DeleteComplaintUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.complaint;
 
 public interface DeleteComplaintUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/complaint/DeleteComplaintWithReviewUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/complaint/DeleteComplaintWithReviewUseCase.java
@@ -2,11 +2,9 @@ package com.pikachu.purple.application.review.port.in.complaint;
 
 public interface DeleteComplaintWithReviewUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long complaintId,
         String token
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/complaint/GetComplaintFormUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/complaint/GetComplaintFormUseCase.java
@@ -4,12 +4,10 @@ import com.pikachu.purple.application.review.common.dto.ComplaintFormDTO;
 
 public interface GetComplaintFormUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         Long complaintId,
         String token
-    ) {}
+    );
 
     record Result(ComplaintFormDTO complaintFormDTO) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/like/CreateLikeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/like/CreateLikeUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.like;
 
 public interface CreateLikeUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteAllLikeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteAllLikeUseCase.java
@@ -2,8 +2,7 @@ package com.pikachu.purple.application.review.port.in.like;
 
 public interface DeleteAllLikeUseCase {
 
-    void invoke(Command command);
+    void invoke(Long reviewId);
 
-    record Command(Long reviewId) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteLikeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/like/DeleteLikeUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.like;
 
 public interface DeleteLikeUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/CreateReviewDetailUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/CreateReviewDetailUseCase.java
@@ -5,16 +5,12 @@ import java.util.List;
 
 public interface CreateReviewDetailUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         int score,
         String content,
         List<EvaluationFieldVO> evaluationFieldVOs,
         List<String> moodNames
-    ) {
-
-    }
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/CreateReviewSimpleUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/CreateReviewSimpleUseCase.java
@@ -2,12 +2,10 @@ package com.pikachu.purple.application.review.port.in.review;
 
 public interface CreateReviewSimpleUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         int score,
         String content
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/DecreaseLikeCountUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/DecreaseLikeCountUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.review;
 
 public interface DecreaseLikeCountUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/DeleteReviewUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/DeleteReviewUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.review;
 
 public interface DeleteReviewUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long reviewId) {}
+    void invoke(Long reviewId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewByPerfumeIdAndUserUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewByPerfumeIdAndUserUseCase.java
@@ -4,9 +4,7 @@ import com.pikachu.purple.application.review.common.dto.ReviewByUserDTO;
 
 public interface GetReviewByPerfumeIdAndUserUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    Result invoke(Long perfumeId);
 
     record Result(ReviewByUserDTO reviewByUserDTO) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsByPerfumeIdAndSortTypeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsByPerfumeIdAndSortTypeUseCase.java
@@ -5,12 +5,10 @@ import java.util.List;
 
 public interface GetReviewsByPerfumeIdAndSortTypeUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         Long perfumeId,
         String sortType
-    ) {}
+    );
 
     record Result(List<ReviewDTO> reviewDTOs) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/IncreaseLikeCountUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/IncreaseLikeCountUseCase.java
@@ -2,8 +2,7 @@ package com.pikachu.purple.application.review.port.in.review;
 
 public interface IncreaseLikeCountUseCase {
 
-    void invoke(Command command);
+    void invoke(Long reviewId);
 
-    record Command(Long reviewId) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewDetailUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewDetailUseCase.java
@@ -5,14 +5,12 @@ import java.util.List;
 
 public interface UpdateReviewDetailUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long reviewId,
         int score,
         String content,
         List<EvaluationFieldVO> evaluationFieldVOs,
         List<String> moodNames
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewSimpleUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewSimpleUseCase.java
@@ -2,12 +2,10 @@ package com.pikachu.purple.application.review.port.in.review;
 
 public interface UpdateReviewSimpleUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long reviewId,
         int score,
         String content
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/UpdateReviewUseCase.java
@@ -4,14 +4,12 @@ import com.pikachu.purple.domain.review.enums.ReviewType;
 
 public interface UpdateReviewUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long reviewId,
         Long perfumeId,
         ReviewType reviewType,
         String content,
         int score
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/reviewevaluation/CreateReviewEvaluationUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/reviewevaluation/CreateReviewEvaluationUseCase.java
@@ -6,11 +6,9 @@ import java.util.List;
 
 public interface CreateReviewEvaluationUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Review review,
         List<EvaluationFieldVO> evaluationFieldVOs
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateOrUpdateStarRatingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateOrUpdateStarRatingUseCase.java
@@ -4,12 +4,10 @@ import com.pikachu.purple.domain.review.StarRating;
 
 public interface CreateOrUpdateStarRatingUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         Long perfumeId,
         int score
-    ) {}
+    );
 
     record Result(StarRating starRating) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateStarRatingOnboardingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateStarRatingOnboardingUseCase.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 public interface CreateStarRatingOnboardingUseCase {
 
-    void invoke(Command command);
-
-    record Command(List<StarRatingVO> starRatingVOs) {}
+    void invoke(List<StarRatingVO> starRatingVOs);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateStarRatingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/CreateStarRatingUseCase.java
@@ -4,12 +4,10 @@ import com.pikachu.purple.domain.review.StarRating;
 
 public interface CreateStarRatingUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         Long perfumeId,
         int score
-    ) {}
+    );
 
     record Result(StarRating starRating) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/DeleteStarRatingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/DeleteStarRatingUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.review.port.in.starrating;
 
 public interface DeleteStarRatingUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long starRatingId) {}
+    void invoke(Long starRatingId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetAverageScoreByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetAverageScoreByPerfumeIdUseCase.java
@@ -2,9 +2,7 @@ package com.pikachu.purple.application.review.port.in.starrating;
 
 public interface GetAverageScoreByPerfumeIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    Result invoke(Long perfumeId);
 
     record Result(double averageScore) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetReviewsByUserAndSortTypeUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetReviewsByUserAndSortTypeUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetReviewsByUserAndSortTypeUseCase {
 
-    Result invoke(Command command);
-
-    record Command(String sortType) {}
+    Result invoke(String sortType);
 
     record Result(List<ReviewWithPerfumeDTO> reviewWithPerfumeDTOs) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetStarRatingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetStarRatingUseCase.java
@@ -3,12 +3,11 @@ package com.pikachu.purple.application.review.port.in.starrating;
 import com.pikachu.purple.domain.review.StarRating;
 
 public interface GetStarRatingUseCase {
-    Result invoke(Command command);
 
-    record Command(
+    Result invoke(
         Long userId,
         Long perfumeId
-    ) {}
+    );
 
     record Result(StarRating starRating) {}
 }

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetStarRatingsByUserIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/GetStarRatingsByUserIdUseCase.java
@@ -5,9 +5,7 @@ import java.util.List;
 
 public interface GetStarRatingsByUserIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long userId) {}
+    Result invoke(Long userId);
 
     record Result(List<StarRating> starRatings) {}
 

--- a/src/main/java/com/pikachu/purple/application/review/port/in/starrating/UpdateStarRatingUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/starrating/UpdateStarRatingUseCase.java
@@ -4,13 +4,11 @@ import com.pikachu.purple.domain.review.StarRating;
 
 public interface UpdateStarRatingUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         Long perfumeId,
         int previousScore,
         int score
-    ) {}
+    );
 
     record Result(StarRating starRating){}
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/SendComplaintApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/SendComplaintApplicationService.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.application.review.service.application;
 
 import com.pikachu.purple.application.review.port.in.SendComplaintUseCase;
 import com.pikachu.purple.application.review.port.out.MailSender;
+import com.pikachu.purple.domain.review.Complaint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,10 +13,10 @@ public class SendComplaintApplicationService implements SendComplaintUseCase {
     private final MailSender mailSender;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(Complaint complaint) {
         mailSender.send(
-            command.complaint().getId(),
-            command.complaint().getToken()
+            complaint.getId(),
+            complaint.getToken()
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/CreateComplaintApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/CreateComplaintApplicationService.java
@@ -19,11 +19,11 @@ public class CreateComplaintApplicationService implements CreateComplaintUseCase
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long reviewId) {
         Long userId = getCurrentUserAuthentication().userId();
         Complaint complaint = complaintDomainService.create(
             userId,
-            command.reviewId()
+            reviewId
         );
 
         sendComplaintUseCase.invoke(new SendComplaintUseCase.Command(complaint));

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/CreateComplaintApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/CreateComplaintApplicationService.java
@@ -26,7 +26,7 @@ public class CreateComplaintApplicationService implements CreateComplaintUseCase
             reviewId
         );
 
-        sendComplaintUseCase.invoke(new SendComplaintUseCase.Command(complaint));
+        sendComplaintUseCase.invoke(complaint);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintApplicationService.java
@@ -15,12 +15,12 @@ public class DeleteComplaintApplicationService implements DeleteComplaintUseCase
     private final ComplaintDomainService complaintDomainService;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long reviewId) {
         Long userId = getCurrentUserAuthentication().userId();
 
         Complaint complaint = complaintDomainService.find(
             userId,
-            command.reviewId()
+            reviewId
         );
 
         complaintDomainService.delete(complaint.getId());

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintWithReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintWithReviewApplicationService.java
@@ -27,7 +27,7 @@ public class DeleteComplaintWithReviewApplicationService implements
             token
         );
         complaintDomainService.delete(complaintId);
-        deleteReviewUseCase.invoke(new DeleteReviewUseCase.Command(complaint.getReview().getId()));
+        deleteReviewUseCase.invoke(complaint.getReview().getId());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintWithReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/DeleteComplaintWithReviewApplicationService.java
@@ -18,12 +18,15 @@ public class DeleteComplaintWithReviewApplicationService implements
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long complaintId,
+        String token
+    ) {
         Complaint complaint = complaintDomainService.find(
-            command.complaintId(),
-            command.token()
+            complaintId,
+            token
         );
-        complaintDomainService.delete(command.complaintId());
+        complaintDomainService.delete(complaintId);
         deleteReviewUseCase.invoke(new DeleteReviewUseCase.Command(complaint.getReview().getId()));
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/complaint/GetComplaintFormApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/complaint/GetComplaintFormApplicationService.java
@@ -23,10 +23,13 @@ public class GetComplaintFormApplicationService implements GetComplaintFormUseCa
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long complaintId,
+        String token
+    ) {
         Complaint complaint = complaintDomainService.find(
-            command.complaintId(),
-            command.token()
+            complaintId,
+            token
         );
 
         Review review = reviewDomainService.findWithPerfume(complaint.getReview().getId());

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/CreateLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/CreateLikeApplicationService.java
@@ -18,21 +18,21 @@ public class CreateLikeApplicationService implements CreateLikeUseCase {
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long reviewId) {
         Long userId = getCurrentUserAuthentication().userId();
 
         validateNotExist(
             userId,
-            command.reviewId()
+            reviewId
         );
 
 
         likeDomainService.create(
             userId,
-            command.reviewId()
+            reviewId
         );
 
-        increaseLikeCountUseCase.invoke(new IncreaseLikeCountUseCase.Command(command.reviewId()));
+        increaseLikeCountUseCase.invoke(new IncreaseLikeCountUseCase.Command(reviewId));
     }
 
     private void validateNotExist(

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/CreateLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/CreateLikeApplicationService.java
@@ -32,7 +32,7 @@ public class CreateLikeApplicationService implements CreateLikeUseCase {
             reviewId
         );
 
-        increaseLikeCountUseCase.invoke(new IncreaseLikeCountUseCase.Command(reviewId));
+        increaseLikeCountUseCase.invoke(reviewId);
     }
 
     private void validateNotExist(

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteAllLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteAllLikeApplicationService.java
@@ -14,10 +14,8 @@ public class DeleteAllLikeApplicationService implements DeleteAllLikeUseCase {
 
     @Transactional
     @Override
-    public void invoke(Command command) {
-
-        likeDomainService.deleteAll(command.reviewId());
-
+    public void invoke(Long reviewId) {
+        likeDomainService.deleteAll(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteLikeApplicationService.java
@@ -18,15 +18,15 @@ public class DeleteLikeApplicationService implements DeleteLikeUseCase {
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long reviewId) {
         Long userId = getCurrentUserAuthentication().userId();
 
         likeDomainService.delete(
             userId,
-            command.reviewId()
+            reviewId
         );
 
-        decreaseLikeCountUseCase.invoke(new DecreaseLikeCountUseCase.Command(command.reviewId()));
+        decreaseLikeCountUseCase.invoke(new DecreaseLikeCountUseCase.Command(reviewId));
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteLikeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/like/DeleteLikeApplicationService.java
@@ -26,7 +26,7 @@ public class DeleteLikeApplicationService implements DeleteLikeUseCase {
             reviewId
         );
 
-        decreaseLikeCountUseCase.invoke(new DecreaseLikeCountUseCase.Command(reviewId));
+        decreaseLikeCountUseCase.invoke(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewDetailApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewDetailApplicationService.java
@@ -35,10 +35,8 @@ public class CreateReviewDetailApplicationService implements CreateReviewDetailU
         List<String> moodNames
     ) {
         CreateOrUpdateStarRatingUseCase.Result starRatingResult = createOrUpdateStarRatingUseCase.invoke(
-            new CreateOrUpdateStarRatingUseCase.Command(
-                perfumeId,
-                score
-            )
+            perfumeId,
+            score
         );
 
         StarRating starRating = starRatingResult.starRating();
@@ -58,13 +56,11 @@ public class CreateReviewDetailApplicationService implements CreateReviewDetailU
         );
 
         createReviewEvaluationUseCase.invoke(
-            new CreateReviewEvaluationUseCase.Command(
-                review,
-                evaluationFieldVOs
-            )
+            review,
+            evaluationFieldVOs
         );
 
-        createUserAccordUseCase.invoke(new CreateUserAccordUseCase.Command(perfume.getId()));
+        createUserAccordUseCase.invoke(perfume.getId());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewDetailApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewDetailApplicationService.java
@@ -5,11 +5,13 @@ import com.pikachu.purple.application.review.port.in.reviewevaluation.CreateRevi
 import com.pikachu.purple.application.review.port.in.starrating.CreateOrUpdateStarRatingUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.application.user.port.in.useraccord.CreateUserAccordUseCase;
+import com.pikachu.purple.bootstrap.review.vo.EvaluationFieldVO;
 import com.pikachu.purple.domain.perfume.Perfume;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.StarRating;
 import com.pikachu.purple.domain.review.enums.ReviewType;
 import com.pikachu.purple.domain.user.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,11 +27,17 @@ public class CreateReviewDetailApplicationService implements CreateReviewDetailU
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long perfumeId,
+        int score,
+        String content,
+        List<EvaluationFieldVO> evaluationFieldVOs,
+        List<String> moodNames
+    ) {
         CreateOrUpdateStarRatingUseCase.Result starRatingResult = createOrUpdateStarRatingUseCase.invoke(
             new CreateOrUpdateStarRatingUseCase.Command(
-                command.perfumeId(),
-                command.score()
+                perfumeId,
+                score
             )
         );
 
@@ -40,19 +48,19 @@ public class CreateReviewDetailApplicationService implements CreateReviewDetailU
         Review review = reviewDomainService.create(
             user.getId(),
             perfume.getId(),
-            command.content(),
+            content,
             ReviewType.DETAIL
         );
 
         reviewDomainService.createReviewMoods(
             review.getId(),
-            command.moodNames()
+            moodNames
         );
 
         createReviewEvaluationUseCase.invoke(
             new CreateReviewEvaluationUseCase.Command(
                 review,
-                command.evaluationFieldVOs()
+                evaluationFieldVOs
             )
         );
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewSimpleApplicationService.java
@@ -28,10 +28,8 @@ public class CreateReviewSimpleApplicationService implements CreateReviewSimpleU
         String content
     ) {
         CreateOrUpdateStarRatingUseCase.Result starRatingResult = createOrUpdateStarRatingUseCase.invoke(
-            new CreateOrUpdateStarRatingUseCase.Command(
-                perfumeId,
-                score
-            )
+            perfumeId,
+            score
         );
 
         StarRating starRating = starRatingResult.starRating();
@@ -45,7 +43,7 @@ public class CreateReviewSimpleApplicationService implements CreateReviewSimpleU
             ReviewType.SIMPLE
         );
 
-        createUserAccordUseCase.invoke(new CreateUserAccordUseCase.Command(perfume.getId()));
+        createUserAccordUseCase.invoke(perfume.getId());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/CreateReviewSimpleApplicationService.java
@@ -22,11 +22,15 @@ public class CreateReviewSimpleApplicationService implements CreateReviewSimpleU
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long perfumeId,
+        int score,
+        String content
+    ) {
         CreateOrUpdateStarRatingUseCase.Result starRatingResult = createOrUpdateStarRatingUseCase.invoke(
             new CreateOrUpdateStarRatingUseCase.Command(
-                command.perfumeId(),
-                command.score()
+                perfumeId,
+                score
             )
         );
 
@@ -37,7 +41,7 @@ public class CreateReviewSimpleApplicationService implements CreateReviewSimpleU
         reviewDomainService.create(
             user.getId(),
             perfume.getId(),
-            command.content(),
+            content,
             ReviewType.SIMPLE
         );
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/DecreaseLikeCountApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/DecreaseLikeCountApplicationService.java
@@ -12,8 +12,8 @@ public class DecreaseLikeCountApplicationService implements DecreaseLikeCountUse
     private final ReviewDomainService reviewDomainService;
 
     @Override
-    public void invoke(Command command) {
-        reviewDomainService.decreaseLikeCount(command.reviewId());
+    public void invoke(Long reviewId) {
+        reviewDomainService.decreaseLikeCount(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
@@ -25,8 +25,8 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
 
     @Transactional
     @Override
-    public void invoke(Command command) {
-        Review review = reviewDomainService.find(command.reviewId());
+    public void invoke(Long reviewId) {
+        Review review = reviewDomainService.find(reviewId);
 
         deleteStarRatingUseCase.invoke(
             new DeleteStarRatingUseCase.Command(review.getStarRating().getId())
@@ -34,20 +34,20 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
 
         if(review.getType() == ReviewType.DETAIL) {
             ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(
-                command.reviewId());
+                reviewId);
 
-            reviewEvaluationDomainService.deleteAll(command.reviewId());
+            reviewEvaluationDomainService.deleteAll(reviewId);
 
             decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
                 review.getPerfume().getId(),
                 reviewEvaluation
             ));
 
-            reviewDomainService.deleteReviewMoods(command.reviewId());
+            reviewDomainService.deleteReviewMoods(reviewId);
         }
 
-        deleteAllLikeUseCase.invoke(new DeleteAllLikeUseCase.Command(command.reviewId()));
-        reviewDomainService.delete(command.reviewId());
+        deleteAllLikeUseCase.invoke(new DeleteAllLikeUseCase.Command(reviewId));
+        reviewDomainService.delete(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/DeleteReviewApplicationService.java
@@ -28,9 +28,7 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
     public void invoke(Long reviewId) {
         Review review = reviewDomainService.find(reviewId);
 
-        deleteStarRatingUseCase.invoke(
-            new DeleteStarRatingUseCase.Command(review.getStarRating().getId())
-        );
+        deleteStarRatingUseCase.invoke(review.getStarRating().getId());
 
         if(review.getType() == ReviewType.DETAIL) {
             ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(
@@ -38,15 +36,15 @@ public class DeleteReviewApplicationService implements DeleteReviewUseCase {
 
             reviewEvaluationDomainService.deleteAll(reviewId);
 
-            decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
+            decreaseEvaluationStatisticUseCase.invoke(
                 review.getPerfume().getId(),
                 reviewEvaluation
-            ));
+            );
 
             reviewDomainService.deleteReviewMoods(reviewId);
         }
 
-        deleteAllLikeUseCase.invoke(new DeleteAllLikeUseCase.Command(reviewId));
+        deleteAllLikeUseCase.invoke(reviewId);
         reviewDomainService.delete(reviewId);
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewByPerfumeIdAndUserApplicationService.java
@@ -27,17 +27,17 @@ public class GetReviewByPerfumeIdAndUserApplicationService implements
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(Long perfumeId) {
         Long userId = getCurrentUserAuthentication().userId();
 
         Review review = reviewDomainService.findWithPerfumeAndReviewEvaluationAndMood(
             userId,
-            command.perfumeId()
+            perfumeId
         );
 
         StarRating starRating = starRatingDomainService.findByUserIdAndPerfumeId(
             userId,
-            command.perfumeId()
+            perfumeId
         );
 
         ReviewByUserDTO reviewByUserDTO = null;

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsByPerfumeIdAndSortTypeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsByPerfumeIdAndSortTypeApplicationService.java
@@ -25,35 +25,38 @@ public class GetReviewsByPerfumeIdAndSortTypeApplicationService implements
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long perfumeId,
+        String sortType
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
-        SortType sortType = SortType.transByStr(command.sortType());
+        SortType getSortType = SortType.transByStr(sortType);
 
         List<Review> reviews = new ArrayList<>();
 
-        switch (sortType) {
+        switch (getSortType) {
             case LIKED:
                 reviews = reviewDomainService.findAllOrderByLikeCountDesc(
                     userId,
-                    command.perfumeId()
+                    perfumeId
                 );
                 break;
             case LATEST:
                 reviews = reviewDomainService.findAllWithPerfumeAndReviewEvaluationAndMoodAndIsComplainedOrderByCreatedAtDesc(
                     userId,
-                    command.perfumeId()
+                    perfumeId
                 );
                 break;
             case STAR_RATING_HIGH:
                 reviews = reviewDomainService.findAllWithPerfumeAndReviewEvaluationAndMoodAndIsComplainedOrderByScoreDesc(
                     userId,
-                    command.perfumeId()
+                    perfumeId
                 );
                 break;
             case STAR_RATING_LOW:
                 reviews = reviewDomainService.findAllWithPerfumeAndReviewEvaluationAndMoodAndIsComplainedOrderByScoreAsc(
                     userId,
-                    command.perfumeId()
+                    perfumeId
                 );
                 break;
             default:

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/IncreaseLikeCountApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/IncreaseLikeCountApplicationService.java
@@ -12,8 +12,8 @@ public class IncreaseLikeCountApplicationService implements IncreaseLikeCountUse
     private final ReviewDomainService reviewDomainService;
 
     @Override
-    public void invoke(Command command) {
-        reviewDomainService.increaseLikeCount(command.reviewId());
+    public void invoke(Long reviewId) {
+        reviewDomainService.increaseLikeCount(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewApplicationService.java
@@ -7,6 +7,7 @@ import com.pikachu.purple.application.review.port.in.starrating.GetStarRatingUse
 import com.pikachu.purple.application.review.port.in.starrating.UpdateStarRatingUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.StarRating;
+import com.pikachu.purple.domain.review.enums.ReviewType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,30 +20,32 @@ public class UpdateReviewApplicationService implements UpdateReviewUseCase {
     private final UpdateStarRatingUseCase updateStarRatingUseCase;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long reviewId,
+        Long perfumeId,
+        ReviewType reviewType,
+        String content,
+        int score
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
 
         reviewDomainService.update(
-            command.reviewId(),
-            command.content(),
-            command.reviewType()
+            reviewId,
+            content,
+            reviewType
         );
 
         GetStarRatingUseCase.Result starRatingResult = getStarRatingUseCase.invoke(
-            new GetStarRatingUseCase.Command(
-                userId,
-                command.perfumeId()
-            )
+            userId,
+            perfumeId
         );
 
         StarRating previousStarRating = starRatingResult.starRating();
 
         updateStarRatingUseCase.invoke(
-            new UpdateStarRatingUseCase.Command(
-                previousStarRating.getPerfume().getId(),
-                previousStarRating.getScore(),
-                command.score()
-            )
+            previousStarRating.getPerfume().getId(),
+            previousStarRating.getScore(),
+            score
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
@@ -8,9 +8,11 @@ import com.pikachu.purple.application.review.service.domain.ReviewEvaluationDoma
 import com.pikachu.purple.application.review.util.ReviewEvaluationConverter;
 import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.DecreaseEvaluationStatisticUseCase;
 import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.IncreaseEvaluationStatisticUseCase;
+import com.pikachu.purple.bootstrap.review.vo.EvaluationFieldVO;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.ReviewEvaluation;
 import com.pikachu.purple.domain.review.enums.ReviewType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,26 +30,32 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
 
     @Transactional
     @Override
-    public void invoke(Command command) {
-        Review review = reviewDomainService.findWithPerfume(command.reviewId());
+    public void invoke(
+        Long reviewId,
+        int score,
+        String content,
+        List<EvaluationFieldVO> evaluationFieldVOs,
+        List<String> moodNames
+    ) {
+        Review review = reviewDomainService.findWithPerfume(reviewId);
 
         if(review.getType() == ReviewType.SIMPLE) {
             createReviewEvaluationUseCase.invoke(
                 new CreateReviewEvaluationUseCase.Command(
                     review,
-                    command.evaluationFieldVOs()
+                    evaluationFieldVOs
                 )
             );
 
             reviewDomainService.createReviewMoods(
                 review.getId(),
-                command.moodNames()
+                moodNames
             );
         }
 
         else{
             ReviewEvaluation beforeReviewEvaluation = reviewEvaluationDomainService.findAll(
-                command.reviewId());
+                reviewId);
 
             decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
                     review.getPerfume().getId(),
@@ -56,8 +64,8 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
             );
 
             ReviewEvaluation afterReviewEvaluation = ReviewEvaluationConverter.of(
-                command.reviewId(),
-                command.evaluationFieldVOs()
+                reviewId,
+                evaluationFieldVOs
             );
             reviewEvaluationDomainService.updateAll(
                 afterReviewEvaluation
@@ -69,17 +77,17 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
             ));
 
             reviewDomainService.updateReviewMood(
-                command.reviewId(),
-                command.moodNames()
+                reviewId,
+                moodNames
             );
         }
 
         updateReviewUseCase.invoke(new UpdateReviewUseCase.Command(
-                command.reviewId(),
+                reviewId,
                 review.getPerfume().getId(),
                 ReviewType.DETAIL,
-                command.content(),
-                command.score()
+                content,
+                score
             )
         );
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewDetailApplicationService.java
@@ -41,10 +41,8 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
 
         if(review.getType() == ReviewType.SIMPLE) {
             createReviewEvaluationUseCase.invoke(
-                new CreateReviewEvaluationUseCase.Command(
-                    review,
-                    evaluationFieldVOs
-                )
+                review,
+                evaluationFieldVOs
             );
 
             reviewDomainService.createReviewMoods(
@@ -57,10 +55,9 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
             ReviewEvaluation beforeReviewEvaluation = reviewEvaluationDomainService.findAll(
                 reviewId);
 
-            decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
-                    review.getPerfume().getId(),
-                    beforeReviewEvaluation
-                )
+            decreaseEvaluationStatisticUseCase.invoke(
+                review.getPerfume().getId(),
+                beforeReviewEvaluation
             );
 
             ReviewEvaluation afterReviewEvaluation = ReviewEvaluationConverter.of(
@@ -71,10 +68,10 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
                 afterReviewEvaluation
             );
 
-            increaseEvaluationStatisticUseCase.invoke(new IncreaseEvaluationStatisticUseCase.Command(
+            increaseEvaluationStatisticUseCase.invoke(
                 review.getPerfume().getId(),
                 afterReviewEvaluation
-            ));
+            );
 
             reviewDomainService.updateReviewMood(
                 reviewId,
@@ -82,13 +79,12 @@ public class UpdateReviewDetailApplicationService implements UpdateReviewDetailU
             );
         }
 
-        updateReviewUseCase.invoke(new UpdateReviewUseCase.Command(
-                reviewId,
-                review.getPerfume().getId(),
-                ReviewType.DETAIL,
-                content,
-                score
-            )
+        updateReviewUseCase.invoke(
+            reviewId,
+            review.getPerfume().getId(),
+            ReviewType.DETAIL,
+            content,
+            score
         );
 
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
@@ -23,26 +23,30 @@ public class UpdateReviewSimpleApplicationService implements UpdateReviewSimpleU
 
     @Transactional
     @Override
-    public void invoke(Command command) {
-        Review review = reviewDomainService.findWithPerfume(command.reviewId());
+    public void invoke(
+        Long reviewId,
+        int score,
+        String content
+    ) {
+        Review review = reviewDomainService.findWithPerfume(reviewId);
 
         if(review.getType() == ReviewType.DETAIL) {
-            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(command.reviewId());
-            reviewEvaluationDomainService.deleteAll(command.reviewId());
+            ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(reviewId);
+            reviewEvaluationDomainService.deleteAll(reviewId);
             decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
                     review.getPerfume().getId(),
                     reviewEvaluation
                 )
             );
-            reviewDomainService.deleteReviewMoods(command.reviewId());
+            reviewDomainService.deleteReviewMoods(reviewId);
         }
 
         updateReviewUseCase.invoke(new UpdateReviewUseCase.Command(
-            command.reviewId(),
+            reviewId,
             review.getPerfume().getId(),
             ReviewType.SIMPLE,
-            command.content(),
-            command.score()
+            content,
+            score
             )
         );
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/UpdateReviewSimpleApplicationService.java
@@ -33,21 +33,19 @@ public class UpdateReviewSimpleApplicationService implements UpdateReviewSimpleU
         if(review.getType() == ReviewType.DETAIL) {
             ReviewEvaluation reviewEvaluation = reviewEvaluationDomainService.findAll(reviewId);
             reviewEvaluationDomainService.deleteAll(reviewId);
-            decreaseEvaluationStatisticUseCase.invoke(new DecreaseEvaluationStatisticUseCase.Command(
-                    review.getPerfume().getId(),
-                    reviewEvaluation
-                )
+            decreaseEvaluationStatisticUseCase.invoke(
+                review.getPerfume().getId(),
+                reviewEvaluation
             );
             reviewDomainService.deleteReviewMoods(reviewId);
         }
 
-        updateReviewUseCase.invoke(new UpdateReviewUseCase.Command(
+        updateReviewUseCase.invoke(
             reviewId,
             review.getPerfume().getId(),
             ReviewType.SIMPLE,
             content,
             score
-            )
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/CreateReviewEvaluationApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/reviewevaluation/CreateReviewEvaluationApplicationService.java
@@ -4,8 +4,10 @@ import com.pikachu.purple.application.review.port.in.reviewevaluation.CreateRevi
 import com.pikachu.purple.application.review.service.domain.ReviewEvaluationDomainService;
 import com.pikachu.purple.application.review.util.ReviewEvaluationConverter;
 import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.IncreaseEvaluationStatisticUseCase;
+import com.pikachu.purple.bootstrap.review.vo.EvaluationFieldVO;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.ReviewEvaluation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,21 +19,20 @@ public class CreateReviewEvaluationApplicationService implements CreateReviewEva
     private final IncreaseEvaluationStatisticUseCase increaseEvaluationStatisticUseCase;
 
     @Override
-    public void invoke(Command command) {
-
-        Review review = command.review();
+    public void invoke(
+        Review review,
+        List<EvaluationFieldVO> evaluationFieldVOs
+    ) {
         ReviewEvaluation reviewEvaluation = ReviewEvaluationConverter.of(
             review.getId(),
-            command.evaluationFieldVOs()
+            evaluationFieldVOs
         );
 
         reviewEvaluationDomainService.createAll(reviewEvaluation);
 
         increaseEvaluationStatisticUseCase.invoke(
-            new IncreaseEvaluationStatisticUseCase.Command(
-                review.getPerfume().getId(),
-                reviewEvaluation
-            )
+            review.getPerfume().getId(),
+            reviewEvaluation
         );
     }
     

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateOrUpdateStarRatingOnboardingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateOrUpdateStarRatingOnboardingApplicationService.java
@@ -23,33 +23,30 @@ public class CreateOrUpdateStarRatingOnboardingApplicationService implements
 
 
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long perfumeId,
+        int score
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
 
         GetStarRatingUseCase.Result getStarRatingResult = getStarRatingUseCase.invoke(
-            new GetStarRatingUseCase.Command(
-                userId,
-                command.perfumeId()
-            )
+            userId,
+            perfumeId
         );
 
         StarRating starRating;
         if (getStarRatingResult.starRating() == null) {
             CreateStarRatingUseCase.Result createStarRatingResult = createStarRatingUseCase.invoke(
-                new CreateStarRatingUseCase.Command(
-                    command.perfumeId(),
-                    command.score()
-                )
+                perfumeId,
+                score
             );
             starRating = createStarRatingResult.starRating();
         } else {
             StarRating previousStarRating = getStarRatingResult.starRating();
             UpdateStarRatingUseCase.Result updateStarRatingResult = updateStarRatingUseCase.invoke(
-                new UpdateStarRatingUseCase.Command(
-                    previousStarRating.getPerfume().getId(),
-                    previousStarRating.getScore(),
-                    command.score()
-                )
+                previousStarRating.getPerfume().getId(),
+                previousStarRating.getScore(),
+                score
             );
             starRating = updateStarRatingResult.starRating();
         }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateStarRatingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateStarRatingApplicationService.java
@@ -21,20 +21,21 @@ public class CreateStarRatingApplicationService implements CreateStarRatingUseCa
 
     @Override
     @Transactional
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long perfumeId,
+        int score
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
 
         StarRating starRating = starRatingDomainService.create(
             userId,
-            command.perfumeId(),
-            command.score()
+            perfumeId,
+            score
         );
 
         increaseStarRatingStatisticUseCase.invoke(
-            new IncreaseStarRatingStatisticUseCase.Command(
-                starRating.getPerfume().getId(),
-                starRating.getScore()
-            )
+            starRating.getPerfume().getId(),
+            starRating.getScore()
         );
 
         // TODO: 별점 갱신 후 콜백으로 처리

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateStarRatingOnboardingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/CreateStarRatingOnboardingApplicationService.java
@@ -7,6 +7,8 @@ import com.pikachu.purple.application.review.port.in.starrating.CreateStarRating
 import com.pikachu.purple.application.review.service.domain.StarRatingDomainService;
 import com.pikachu.purple.application.statistic.port.in.starratingstatistic.IncreaseStarRatingStatisticsUseCase;
 import com.pikachu.purple.application.user.port.in.useraccord.CreateUserAccordOnboardingUseCase;
+import com.pikachu.purple.bootstrap.onboarding.vo.StarRatingVO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,19 +25,15 @@ public class CreateStarRatingOnboardingApplicationService implements
 
     @Override
     @Transactional
-    public void invoke(Command command) {
+    public void invoke(List<StarRatingVO> starRatingVOs) {
         Long userId = getCurrentUserAuthentication().userId();
 
         starRatingDomainService.createOnboarding(
             userId,
-            command.starRatingVOs()
+            starRatingVOs
         );
 
-        increaseStarRatingStatisticsUseCase.invoke(
-            new IncreaseStarRatingStatisticsUseCase.Command(
-                command.starRatingVOs()
-            )
-        );
+        increaseStarRatingStatisticsUseCase.invoke(starRatingVOs);
 
         // TODO: 별점 갱신 후 콜백으로 처리
 //        List<Long> perfumeIds = command.starRatingVOs().stream()

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/DeleteStarRatingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/DeleteStarRatingApplicationService.java
@@ -17,14 +17,12 @@ public class DeleteStarRatingApplicationService implements DeleteStarRatingUseCa
 
     @Transactional
     @Override
-    public void invoke(Command command) {
-        StarRating starRating = starRatingDomainService.deleteById(command.starRatingId());
+    public void invoke(Long starRatingId) {
+        StarRating starRating = starRatingDomainService.deleteById(starRatingId);
 
         decreaseStarRatingStatisticUseCase.invoke(
-            new DecreaseStarRatingStatisticUseCase.Command(
-                starRating.getPerfume().getId(),
-                starRating.getScore()
-            )
+            starRating.getPerfume().getId(),
+            starRating.getScore()
         );
     }
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetAverageScoreByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetAverageScoreByPerfumeIdApplicationService.java
@@ -15,10 +15,11 @@ public class GetAverageScoreByPerfumeIdApplicationService implements
     private final StarRatingDomainService starRatingDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        List<StarRating> starRatings = starRatingDomainService.findAll(command.perfumeId());
+    public Result invoke(Long perfumeId) {
+        List<StarRating> starRatings = starRatingDomainService.findAll(perfumeId);
         double totalScore = starRatings.stream().mapToInt(StarRating::getScore).sum();
         double averageScore = Math.round(totalScore / starRatings.size() * 10) / 10.0;
         return new Result(averageScore);
     }
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetReviewsByUserAndSortTypeApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetReviewsByUserAndSortTypeApplicationService.java
@@ -26,12 +26,12 @@ public class GetReviewsByUserAndSortTypeApplicationService implements
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(String sortType) {
         Long userId = getCurrentUserAuthentication().userId();
-        SortType sortType = SortType.transByStr(command.sortType());
+        SortType getSortType = SortType.transByStr(sortType);
 
         List<StarRating> starRatings = new ArrayList<>();
-        switch (sortType) {
+        switch (getSortType) {
             case LIKED:
                 starRatings = starRatingDomainService.findAllOrderByLikeCountDesc(userId);
                 break;

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetStarRatingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetStarRatingApplicationService.java
@@ -13,12 +13,16 @@ public class GetStarRatingApplicationService implements GetStarRatingUseCase {
     private final StarRatingDomainService starRatingDomainService;
 
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long userId,
+        Long perfumeId
+    ) {
         StarRating starRating = starRatingDomainService.findByUserIdAndPerfumeId(
-            command.userId(),
-            command.perfumeId()
+            userId,
+            perfumeId
         );
 
         return new Result(starRating);
     }
+
 }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetStarRatingsByUserIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/GetStarRatingsByUserIdApplicationService.java
@@ -14,8 +14,8 @@ public class GetStarRatingsByUserIdApplicationService implements GetStarRatingsB
     private final StarRatingDomainService starRatingDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        List<StarRating> starRatings = starRatingDomainService.findAllWithPerfumeAndPerfumeAccordByUserId(command.userId());
+    public Result invoke(Long userId) {
+        List<StarRating> starRatings = starRatingDomainService.findAllWithPerfumeAndPerfumeAccordByUserId(userId);
 
         return new Result(starRatings);
     }

--- a/src/main/java/com/pikachu/purple/application/review/service/application/starrating/UpdateStarRatingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/starrating/UpdateStarRatingApplicationService.java
@@ -23,27 +23,27 @@ public class UpdateStarRatingApplicationService implements UpdateStarRatingUseCa
 
     @Override
     @Transactional
-    public Result invoke(Command command) {
+    public Result invoke(
+        Long perfumeId,
+        int previousScore,
+        int score
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
 
         decreaseStarRatingStatisticUseCase.invoke(
-            new DecreaseStarRatingStatisticUseCase.Command(
-                command.perfumeId(),
-                command.previousScore()
-            )
+            perfumeId,
+            previousScore
         );
 
         StarRating starRating = starRatingDomainService.updateScore(
             userId,
-            command.perfumeId(),
-            command.score()
+            perfumeId,
+            score
         );
 
         increaseStarRatingStatisticUseCase.invoke(
-            new IncreaseStarRatingStatisticUseCase.Command(
-                starRating.getPerfume().getId(),
-                starRating.getScore()
-            )
+            starRating.getPerfume().getId(),
+            starRating.getScore()
         );
 
         // TODO: 별점 갱신 후 콜백으로 처리

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/GetPerfumeStatisticByPerfumeIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/GetPerfumeStatisticByPerfumeIdUseCase.java
@@ -7,9 +7,7 @@ import java.util.List;
 
 public interface GetPerfumeStatisticByPerfumeIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    Result invoke(Long perfumeId);
 
     record Result(
         List<StarRatingStatisticDTO> starRatingStatistics,

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/DecreaseEvaluationStatisticUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/DecreaseEvaluationStatisticUseCase.java
@@ -4,11 +4,9 @@ import com.pikachu.purple.domain.review.ReviewEvaluation;
 
 public interface DecreaseEvaluationStatisticUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         ReviewEvaluation reviewEvaluation
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/IncreaseEvaluationStatisticUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/evaluationstatistic/IncreaseEvaluationStatisticUseCase.java
@@ -3,11 +3,10 @@ package com.pikachu.purple.application.statistic.port.in.evaluationstatistic;
 import com.pikachu.purple.domain.review.ReviewEvaluation;
 
 public interface IncreaseEvaluationStatisticUseCase {
-    void invoke(Command command);
 
-    record Command(
+    void invoke(
         Long perfumeId,
         ReviewEvaluation reviewEvaluation
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/DecreaseStarRatingStatisticUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/DecreaseStarRatingStatisticUseCase.java
@@ -2,11 +2,9 @@ package com.pikachu.purple.application.statistic.port.in.starratingstatistic;
 
 public interface DecreaseStarRatingStatisticUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         int score
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/IncreaseStarRatingStatisticUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/IncreaseStarRatingStatisticUseCase.java
@@ -2,11 +2,9 @@ package com.pikachu.purple.application.statistic.port.in.starratingstatistic;
 
 public interface IncreaseStarRatingStatisticUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         Long perfumeId,
         int score
-    ) {}
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/IncreaseStarRatingStatisticsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/starratingstatistic/IncreaseStarRatingStatisticsUseCase.java
@@ -5,10 +5,6 @@ import java.util.List;
 
 public interface IncreaseStarRatingStatisticsUseCase {
 
-    void invoke(Command command);
-
-    record Command(
-        List<StarRatingVO> starRatingVOs
-    ) {}
+    void invoke(List<StarRatingVO> starRatingVOs);
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdApplicationService.java
@@ -24,20 +24,20 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
     private final StarRatingStatisticDomainService starRatingStatisticDomainService;
 
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(Long perfumeId) {
         EvaluationStatistic evaluationStatistic = evaluationStatisticDomainService.findOrderByVotesDesc(
-            command.perfumeId());
+            perfumeId);
 
         List<EvaluationFieldDTO<EvaluationOptionStatisticDTO>> evaluationFieldDTOs = new ArrayList<>();
         for (EvaluationFieldType evaluationField : evaluationStatistic.getFields(
-            command.perfumeId())) {
+            perfumeId)) {
             int totalVotesByField = evaluationStatistic.getOptions(
-                    command.perfumeId(),
+                    perfumeId,
                     evaluationField
                 ).stream()
                 .mapToInt(
                     evaluationOption -> evaluationStatistic.getVotes(
-                        command.perfumeId(),
+                        perfumeId,
                         evaluationField,
                         evaluationOption
                     )
@@ -46,7 +46,7 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
             List<EvaluationOptionStatisticDTO> evaluationOptionStatisticDTOs = new ArrayList<>();
             List<EvaluationOptionType> evaluationOptions =
                 evaluationStatistic.getOptions(
-                    command.perfumeId(),
+                    perfumeId,
                     evaluationField
                 );
             for (int i = 0; i < evaluationOptions.size(); i++) {
@@ -54,7 +54,7 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
 
                 EvaluationOptionType evaluationOption = evaluationOptions.get(i);
                 int votes = evaluationStatistic.getVotes(
-                    command.perfumeId(),
+                    perfumeId,
                     evaluationField,
                     evaluationOption
                 );
@@ -77,7 +77,7 @@ public class GetPerfumeStatisticByPerfumeIdApplicationService implements
         }
 
         List<StarRatingStatistic> starRatingStatistics = starRatingStatisticDomainService
-            .findAll(command.perfumeId());
+            .findAll(perfumeId);
         int totalVotes = starRatingStatistics.stream().mapToInt(StarRatingStatistic::getVotes)
             .sum();
 

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/DecreaseEvaluationStatisticApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/DecreaseEvaluationStatisticApplicationService.java
@@ -14,20 +14,21 @@ public class DecreaseEvaluationStatisticApplicationService implements
     private final EvaluationStatisticDomainService evaluationStatisticDomainService;
 
     @Override
-    public void invoke(Command command) {
-        ReviewEvaluation reviewEvaluation = command.reviewEvaluation();
+    public void invoke(
+        Long perfumeId,
+        ReviewEvaluation reviewEvaluation
+    ) {
         reviewEvaluation.getReviewIdSet().forEach(
             reviewId -> reviewEvaluation.getFields(reviewId).forEach(
                 field -> reviewEvaluation.getOptions(reviewId, field).forEach(
                     option -> evaluationStatisticDomainService.decreaseVotes(
-                        command.perfumeId(),
+                        perfumeId,
                         field,
                         option
                     )
                 )
             )
         );
-
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/IncreaseEvaluationStatisticApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/IncreaseEvaluationStatisticApplicationService.java
@@ -14,13 +14,15 @@ public class IncreaseEvaluationStatisticApplicationService implements
     private final EvaluationStatisticDomainService evaluationStatisticDomainService;
 
     @Override
-    public void invoke(Command command) {
-        ReviewEvaluation reviewEvaluation = command.reviewEvaluation();
+    public void invoke(
+        Long perfumeId,
+        ReviewEvaluation reviewEvaluation
+    ) {
         reviewEvaluation.getReviewIdSet().forEach(
             reviewId -> reviewEvaluation.getFields(reviewId).forEach(
                 field -> reviewEvaluation.getOptions(reviewId, field).forEach(
                     option -> evaluationStatisticDomainService.increaseVotes(
-                        command.perfumeId(),
+                        perfumeId,
                         field,
                         option
                     )

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/DecreaseStarRatingStatisticApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/DecreaseStarRatingStatisticApplicationService.java
@@ -13,10 +13,13 @@ public class DecreaseStarRatingStatisticApplicationService implements
     private final StarRatingStatisticDomainService starRatingStatisticDomainService;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long perfumeId,
+        int score
+    ) {
         starRatingStatisticDomainService.decreaseVotes(
-            command.perfumeId(),
-            command.score()
+            perfumeId,
+            score
         );
 
     }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/IncreaseStarRatingStatisticApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/IncreaseStarRatingStatisticApplicationService.java
@@ -13,10 +13,13 @@ public class IncreaseStarRatingStatisticApplicationService implements
     private final StarRatingStatisticDomainService starRatingStatisticDomainService;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        Long perfumeId,
+        int score
+    ) {
         starRatingStatisticDomainService.increaseVotes(
-            command.perfumeId(),
-            command.score()
+            perfumeId,
+            score
         );
 
     }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/IncreaseStarRatingStatisticsApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/IncreaseStarRatingStatisticsApplicationService.java
@@ -3,6 +3,7 @@ package com.pikachu.purple.application.statistic.service.application.starratings
 import com.pikachu.purple.application.statistic.port.in.starratingstatistic.IncreaseStarRatingStatisticsUseCase;
 import com.pikachu.purple.application.statistic.service.domain.StarRatingStatisticDomainService;
 import com.pikachu.purple.bootstrap.onboarding.vo.StarRatingVO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,14 +15,13 @@ public class IncreaseStarRatingStatisticsApplicationService implements
     private final StarRatingStatisticDomainService starRatingStatisticDomainService;
 
     @Override
-    public void invoke(Command command) {
-        for (StarRatingVO starRatingVO : command.starRatingVOs()) {
+    public void invoke(List<StarRatingVO> starRatingVOs) {
+        for (StarRatingVO starRatingVO : starRatingVOs) {
             starRatingStatisticDomainService.increaseVotes(
                 starRatingVO.perfumeId(),
                 starRatingVO.score()
             );
         }
-
     }
 
 }

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/UpdateStarRatingStatisticApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/starratingstatistic/UpdateStarRatingStatisticApplicationService.java
@@ -18,10 +18,8 @@ public class UpdateStarRatingStatisticApplicationService implements
     @Override
     public void invoke(Command command) {
         GetStarRatingUseCase.Result result = getStarRatingUseCase.invoke(
-            new GetStarRatingUseCase.Command(
-                command.userId(),
-                command.perfumeId()
-            )
+            command.userId(),
+            command.perfumeId()
         );
 
         StarRating previousStarRating = result.starRating();

--- a/src/main/java/com/pikachu/purple/application/user/port/in/RefreshJwtTokenUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/RefreshJwtTokenUseCase.java
@@ -2,18 +2,8 @@ package com.pikachu.purple.application.user.port.in;
 
 public interface RefreshJwtTokenUseCase {
 
-    RefreshJwtTokenUseCase.Result invoke(RefreshJwtTokenUseCase.Command command);
+    RefreshJwtTokenUseCase.Result invoke(String jwtToken);
 
-    record Command(
-        String jwtToken
-    ) {
-
-    }
-
-    record Result(
-        String jwtToken
-    ) {
-
-    }
+    record Result(String jwtToken) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginTryUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginTryUseCase.java
@@ -5,15 +5,11 @@ import java.net.URISyntaxException;
 
 public interface SocialLoginTryUseCase {
 
-    Result invoke(Command command) throws URISyntaxException;
-
-    record Command(
+    Result invoke(
         SocialLoginProvider socialLoginProvider,
         String frontUrl
-    ) {}
+    ) throws URISyntaxException;
 
-    record Result(
-        String socialLoginUrl
-    ) {}
+    record Result(String socialLoginUrl) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/SocialLoginUseCase.java
@@ -4,21 +4,17 @@ import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 
 public interface SocialLoginUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         SocialLoginProvider socialLoginProvider,
         String authorizationCode,
         String frontUrl
-    ) {}
+    );
 
     record Result(
         String jwtToken,
         boolean isSignUp,
         String nickname,
         String imageUrl
-    ) {
-
-    }
+    ) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/UserSignUpUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/UserSignUpUseCase.java
@@ -4,12 +4,9 @@ import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 
 public interface UserSignUpUseCase {
 
-    void invoke(Command command);
-
-    record Command(
+    void invoke(
         String email,
         SocialLoginProvider socialLoginProvider
-    ) {
-    }
+    );
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/user/GetUserByIdUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/user/GetUserByIdUseCase.java
@@ -4,9 +4,7 @@ import com.pikachu.purple.domain.user.User;
 
 public interface GetUserByIdUseCase {
 
-    Result invoke(Command command);
-
-    record Command(Long userId) {}
+    Result invoke(Long userId);
 
     record Result(User user) {}
 

--- a/src/main/java/com/pikachu/purple/application/user/port/in/user/UpdateProfileUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/user/UpdateProfileUseCase.java
@@ -5,18 +5,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface UpdateProfileUseCase {
 
-    Result invoke(Command command);
-
-    record Command(
+    Result invoke(
         String nickname,
         boolean isChanged,
         MultipartFile picture
-    ) {
+    );
 
-    }
-
-    record Result(User user) {
-
-    }
+    record Result(User user) {}
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/port/in/useraccord/CreateUserAccordUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/user/port/in/useraccord/CreateUserAccordUseCase.java
@@ -2,8 +2,6 @@ package com.pikachu.purple.application.user.port.in.useraccord;
 
 public interface CreateUserAccordUseCase {
 
-    void invoke(Command command);
-
-    record Command(Long perfumeId) {}
+    void invoke(Long perfumeId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/RefreshJwtTokenApplicationService.java
@@ -19,8 +19,7 @@ public class RefreshJwtTokenApplicationService implements RefreshJwtTokenUseCase
     private final UserTokenRepository userTokenRepository;
 
     @Override
-    public Result invoke(Command command) {
-        String jwtToken = command.jwtToken();
+    public Result invoke(String jwtToken) {
         String refreshToken = userTokenService.resolveJwtToken(jwtToken).getRefreshToken();
 
         Long userId = userTokenService.resolveRefreshToken(refreshToken).getUserId();

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginApplicationService.java
@@ -52,10 +52,8 @@ public class SocialLoginApplicationService implements SocialLoginUseCase {
         if (user == null) {
             isSignUp = true;
             userSignUpUseCase.invoke(
-                new UserSignUpUseCase.Command(
-                    email,
-                    socialLoginProvider
-                )
+                email,
+                socialLoginProvider
             );
 
             user = userDomainService.findByEmailAndSocialLoginProvider(

--- a/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginTryApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/SocialLoginTryApplicationService.java
@@ -2,6 +2,7 @@ package com.pikachu.purple.application.user.service.application;
 
 import com.pikachu.purple.application.user.port.in.SocialLoginTryUseCase;
 import com.pikachu.purple.application.user.service.util.SocialLoginService;
+import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,13 @@ public class SocialLoginTryApplicationService implements SocialLoginTryUseCase {
     private final SocialLoginService socialLoginService;
 
     @Override
-    public SocialLoginTryUseCase.Result invoke(Command command)
-        throws URISyntaxException {
+    public SocialLoginTryUseCase.Result invoke(
+        SocialLoginProvider socialLoginProvider,
+        String frontUrl
+    ) throws URISyntaxException {
         URI socialLoginUri = socialLoginService.createUri(
-            command.socialLoginProvider(),
-            command.frontUrl()
+            socialLoginProvider,
+            frontUrl
         );
 
         return new SocialLoginTryUseCase.Result(socialLoginUri.toString());

--- a/src/main/java/com/pikachu/purple/application/user/service/application/UserSignUpApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/UserSignUpApplicationService.java
@@ -4,6 +4,7 @@ import com.pikachu.purple.application.user.port.in.UserSignUpUseCase;
 import com.pikachu.purple.application.user.service.domain.UserDomainService;
 import com.pikachu.purple.application.user.vo.Nickname;
 import com.pikachu.purple.domain.user.User;
+import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,18 +17,22 @@ public class UserSignUpApplicationService implements UserSignUpUseCase {
 
     @Transactional
     @Override
-    public void invoke(Command command) {
+    public void invoke(
+        String email,
+        SocialLoginProvider socialLoginProvider
+    ) {
         User user = userDomainService.findByEmailAndSocialLoginProvider(
-            command.email(),
-            command.socialLoginProvider()
+            email,
+            socialLoginProvider
         );
 
         if(user == null) {
             userDomainService.create(
-                command.email(),
+                email,
                 new Nickname(userDomainService.count()).getValue(),
-                command.socialLoginProvider()
+                socialLoginProvider
             );
         }
     }
+
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/user/GetUserByIdApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/user/GetUserByIdApplicationService.java
@@ -13,9 +13,10 @@ public class GetUserByIdApplicationService implements GetUserByIdUseCase {
     private final UserDomainService userDomainService;
 
     @Override
-    public Result invoke(Command command) {
-        User user = userDomainService.findById(command.userId());
+    public Result invoke(Long userId) {
+        User user = userDomainService.findById(userId);
 
         return new Result(user);
     }
+
 }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/user/UpdateProfileApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/user/UpdateProfileApplicationService.java
@@ -7,6 +7,7 @@ import com.pikachu.purple.application.user.service.domain.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -16,15 +17,19 @@ public class UpdateProfileApplicationService implements UpdateProfileUseCase {
 
     @Transactional
     @Override
-    public Result invoke(Command command) {
+    public Result invoke(
+        String nickname,
+        boolean isChanged,
+        MultipartFile picture
+    ) {
         Long userId = getCurrentUserAuthentication().userId();
 
         return new Result(
             userDomainService.updateProfile(
                 userId,
-                command.nickname(),
-                command.isChanged(),
-                command.picture()
+                nickname,
+                isChanged,
+                picture
             )
         );
     }

--- a/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordApplicationService.java
@@ -22,15 +22,13 @@ public class CreateUserAccordApplicationService implements CreateUserAccordUseCa
     private final GetStarRatingUseCase getStarRatingUseCase;
 
     @Override
-    public void invoke(Command command) {
+    public void invoke(Long perfumeId) {
         Long userId = getCurrentUserAuthentication().userId();
 
-        GetUserByIdUseCase.Result user = getUserByIdUseCase.invoke(new GetUserByIdUseCase.Command(userId));
+        GetUserByIdUseCase.Result user = getUserByIdUseCase.invoke(userId);
         GetStarRatingUseCase.Result starRating = getStarRatingUseCase.invoke(
-            new GetStarRatingUseCase.Command(
-                userId,
-                command.perfumeId()
-            )
+            userId,
+            perfumeId
         );
         List<UserAccord> userAccords = userAccordRecommender.recommend(
             user.user(),

--- a/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordOnboardingApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/CreateUserAccordOnboardingApplicationService.java
@@ -26,8 +26,8 @@ public class CreateUserAccordOnboardingApplicationService implements
     public void invoke() {
         Long userId = getCurrentUserAuthentication().userId();
 
-        GetUserByIdUseCase.Result user = getUserByIdUseCase.invoke(new GetUserByIdUseCase.Command(userId));
-        GetStarRatingsByUserIdUseCase.Result starRatings = getStarRatingsByUserIdUseCase.invoke(new GetStarRatingsByUserIdUseCase.Command(userId));
+        GetUserByIdUseCase.Result user = getUserByIdUseCase.invoke(userId);
+        GetStarRatingsByUserIdUseCase.Result starRatings = getStarRatingsByUserIdUseCase.invoke(userId);
 
         List<UserAccord> userAccords = userAccordRecommender.recommend(
             user.user(),

--- a/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/GetPolarizedUserAccordsByUserApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/user/service/application/useraccord/GetPolarizedUserAccordsByUserApplicationService.java
@@ -42,9 +42,7 @@ public class GetPolarizedUserAccordsByUserApplicationService implements
             MAX_SIZE
         );
 
-        GetStarRatingsByUserIdUseCase.Result result = getStarRatingsByUserIdUseCase.invoke(
-            new GetStarRatingsByUserIdUseCase.Command(userId)
-        );
+        GetStarRatingsByUserIdUseCase.Result result = getStarRatingsByUserIdUseCase.invoke(userId);
 
         List<AccordInfo> preferredAccord = mapToAccordInfo(
             accordsByDesc,

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -51,6 +51,6 @@ public interface AuthApi {
     @Operation(summary = "소셜 로그아웃")
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.OK)
-    SuccessResponse<String> socialLogout() throws URISyntaxException;
+    void socialLogout() throws URISyntaxException;
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/api/AuthApi.java
@@ -27,7 +27,7 @@ public interface AuthApi {
     @PostMapping("/login-try/{provider}")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<SocialLoginTryResponse> socialLoginTry(
-        @PathVariable("provider")SocialLoginProvider provider,
+        @PathVariable("provider") SocialLoginProvider provider,
         @RequestBody SocialLoginRequest request
     ) throws URISyntaxException;
 
@@ -35,7 +35,7 @@ public interface AuthApi {
     @PostMapping("/login/{provider}")
     @ResponseStatus(HttpStatus.OK)
     SuccessResponse<SocialLoginResponse> socialLogin(
-        @PathVariable("provider")SocialLoginProvider provider,
+        @PathVariable("provider") SocialLoginProvider provider,
         @RequestParam String code,
         @RequestBody SocialLoginRequest request
     );

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -75,10 +76,8 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public SuccessResponse<String> socialLogout() {
+    public void socialLogout() {
         socialLogoutUseCase.invoke();
-
-        return SuccessResponse.of(null);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -14,7 +14,6 @@ import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.domain.user.enums.SocialLoginProvider;
 import java.net.URISyntaxException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/auth/controller/AuthController.java
@@ -31,10 +31,8 @@ public class AuthController implements AuthApi {
         SocialLoginRequest request
     ) throws URISyntaxException {
         SocialLoginTryUseCase.Result result = socialLoginTryUseCase.invoke(
-            new SocialLoginTryUseCase.Command(
-                socialLoginProvider,
-                request.frontUrl()
-            )
+            socialLoginProvider,
+            request.frontUrl()
         );
 
         return SuccessResponse.of(
@@ -49,11 +47,9 @@ public class AuthController implements AuthApi {
         SocialLoginRequest request
     ) {
         SocialLoginUseCase.Result result = socialLoginUseCase.invoke(
-            new SocialLoginUseCase.Command(
-                socialLoginProvider,
-                code,
-                request.frontUrl()
-            )
+            socialLoginProvider,
+            code,
+            request.frontUrl()
         );
 
         return SuccessResponse.of(
@@ -70,9 +66,7 @@ public class AuthController implements AuthApi {
     public SuccessResponse<RefreshJwtTokenResponse> refreshJwtToken(
         RefreshJwtTokenRequest request) {
         RefreshJwtTokenUseCase.Result result = refreshJwtTokenUseCase.invoke(
-            new RefreshJwtTokenUseCase.Command(
-                request.jwtToken()
-            )
+            request.jwtToken()
         );
 
         return SuccessResponse.of(

--- a/src/main/java/com/pikachu/purple/bootstrap/complaint/api/ComplaintApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/complaint/api/ComplaintApi.java
@@ -26,8 +26,8 @@ public interface ComplaintApi {
     @Operation(summary = "신고내역 처리")
     @PostMapping("/{complaint-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    void delete(@PathVariable
-        ("complaint-id") Long complaintId,
+    void delete(
+        @PathVariable("complaint-id") Long complaintId,
         @RequestParam String token
     );
 

--- a/src/main/java/com/pikachu/purple/bootstrap/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/complaint/controller/ComplaintController.java
@@ -20,10 +20,10 @@ public class ComplaintController implements ComplaintApi {
         String token,
         Model model
     ) {
-        GetComplaintFormUseCase.Result result = getComplaintFormUseCase.invoke(new GetComplaintFormUseCase.Command(
+        GetComplaintFormUseCase.Result result = getComplaintFormUseCase.invoke(
             complaintId,
             token
-        ));
+        );
 
         model.addAttribute("reportDate", result.complaintFormDTO().reportedAt());
         model.addAttribute("reporterId", result.complaintFormDTO().reporterId());
@@ -41,10 +41,10 @@ public class ComplaintController implements ComplaintApi {
         Long complaintId,
         String token
     ) {
-       deleteComplaintWithReviewUseCase.invoke(new DeleteComplaintWithReviewUseCase.Command(
+       deleteComplaintWithReviewUseCase.invoke(
            complaintId,
            token
-       ));
+       );
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/onboarding/controller/OnboardingController.java
@@ -1,7 +1,6 @@
 package com.pikachu.purple.bootstrap.onboarding.controller;
 
 import com.pikachu.purple.application.review.port.in.starrating.CreateStarRatingOnboardingUseCase;
-import com.pikachu.purple.application.review.port.in.starrating.CreateStarRatingOnboardingUseCase.Command;
 import com.pikachu.purple.bootstrap.onboarding.api.OnboardingApi;
 import com.pikachu.purple.bootstrap.onboarding.dto.request.CreateStarRatingOnboardingRequest;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +14,7 @@ public class OnboardingController implements OnboardingApi {
 
     @Override
     public void createOnboarding(CreateStarRatingOnboardingRequest request) {
-        createStarRatingOnboardingUseCase.invoke(
-            new Command(
-                request.starRatingVOs()
-            )
-        );
+        createStarRatingOnboardingUseCase.invoke(request.starRatingVOs());
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/BrandController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/BrandController.java
@@ -26,9 +26,8 @@ public class BrandController implements BrandApi {
     }
 
     @Override
-    public SuccessResponse<GetPerfumesByBrandNamesResponse> findAllPerfumesByBrandNames(List<String> request) {
-        GetPerfumesByBrandsUseCase.Result result = getPerfumesByBrandsUseCase.invoke(
-            new GetPerfumesByBrandsUseCase.Command(request));
+    public SuccessResponse<GetPerfumesByBrandNamesResponse> findAllPerfumesByBrandNames(List<String> brandNames) {
+        GetPerfumesByBrandsUseCase.Result result = getPerfumesByBrandsUseCase.invoke(brandNames);
 
         return SuccessResponse.of(new GetPerfumesByBrandNamesResponse(result.brandPerfumesDTOs()));
     }

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -24,8 +24,7 @@ public class PerfumeController implements PerfumeApi {
 
     @Override
     public SuccessResponse<GetPerfumeDetailResponse> findAccordsAndNotesByPerfumeId(Long perfumeId) {
-        GetPerfumeDetailByPerfumeIdUseCase.Result result = getPerfumeDetailByPerfumeIdUseCase.invoke(
-            new GetPerfumeDetailByPerfumeIdUseCase.Command(perfumeId));
+        GetPerfumeDetailByPerfumeIdUseCase.Result result = getPerfumeDetailByPerfumeIdUseCase.invoke(perfumeId);
 
         return SuccessResponse.of(new GetPerfumeDetailResponse(result.perfumeDetail()));
     }
@@ -34,8 +33,7 @@ public class PerfumeController implements PerfumeApi {
     public SuccessResponse<GetFragranticaEvaluationResponse> findFragranticaEvaluationByPerfumeId(
         Long perfumeId) {
 
-        GetFragranticaEvaluationByPerfumeIdUseCase.Result result = getFragranticaEvaluationByPerfumeIdUseCase.invoke(
-            new GetFragranticaEvaluationByPerfumeIdUseCase.Command(perfumeId));
+        GetFragranticaEvaluationByPerfumeIdUseCase.Result result = getFragranticaEvaluationByPerfumeIdUseCase.invoke(perfumeId);
 
         return SuccessResponse.of(
             new GetFragranticaEvaluationResponse(result.fragranticaEvaluation()));
@@ -44,8 +42,7 @@ public class PerfumeController implements PerfumeApi {
     @Override
     public SuccessResponse<GetPerfumeStatisticResponse> findPerfumeStatisticResponse(
         Long perfumeId) {
-        GetPerfumeStatisticByPerfumeIdUseCase.Result result = getPerfumeStatisticByPerfumeIdUseCase. invoke(
-            new GetPerfumeStatisticByPerfumeIdUseCase.Command(perfumeId));
+        GetPerfumeStatisticByPerfumeIdUseCase.Result result = getPerfumeStatisticByPerfumeIdUseCase.invoke(perfumeId);
 
         return SuccessResponse.of(
             new GetPerfumeStatisticResponse(
@@ -61,10 +58,8 @@ public class PerfumeController implements PerfumeApi {
         String sortType
     ) {
         GetReviewsByPerfumeIdAndSortTypeUseCase.Result result = getReviewsByPerfumeIdAndSortTypeUseCase.invoke(
-            new GetReviewsByPerfumeIdAndSortTypeUseCase.Command(
-                perfumeId,
-                sortType
-            )
+            perfumeId,
+            sortType
         );
 
         return SuccessResponse.of(new GetReviewsResponse(result.reviewDTOs()));

--- a/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/review/controller/ReviewController.java
@@ -39,24 +39,20 @@ public class ReviewController implements ReviewApi {
     @Override
     public void createSimple(CreateReviewSimpleRequest request) {
         createReviewSimpleUseCase.invoke(
-            new CreateReviewSimpleUseCase.Command(
-                request.perfumeId(),
-                request.score(),
-                request.content()
-            )
+            request.perfumeId(),
+            request.score(),
+            request.content()
         );
     }
 
     @Override
     public void createDetail(CreateReviewDetailRequest request) {
         createReviewDetailUseCase.invoke(
-            new CreateReviewDetailUseCase.Command(
-                request.perfumeId(),
-                request.score(),
-                request.content(),
-                request.evaluationFieldVOs(),
-                request.moodNames()
-            )
+            request.perfumeId(),
+            request.score(),
+            request.content(),
+            request.evaluationFieldVOs(),
+            request.moodNames()
         );
     }
 
@@ -77,11 +73,9 @@ public class ReviewController implements ReviewApi {
         UpdateReviewSimpleRequest request
     ) {
         updateReviewSimpleUseCase.invoke(
-            new UpdateReviewSimpleUseCase.Command(
-                reviewId,
-                request.score(),
-                request.content()
-            )
+            reviewId,
+            request.score(),
+            request.content()
         );
     }
 
@@ -90,38 +84,38 @@ public class ReviewController implements ReviewApi {
         Long reviewId,
         UpdateReviewDetailRequest request
     ) {
-        updateReviewDetailUseCase.invoke(new UpdateReviewDetailUseCase.Command(
+        updateReviewDetailUseCase.invoke(
             reviewId,
             request.score(),
             request.content(),
             request.evaluationFieldVOs(),
             request.moodNames()
-        ));
+        );
     }
 
     @Override
     public void delete(Long reviewId) {
-        deleteReviewUseCase.invoke(new DeleteReviewUseCase.Command(reviewId));
+        deleteReviewUseCase.invoke(reviewId);
     }
 
     @Override
     public void complain(Long reviewId) {
-        createComplaintUseCase.invoke(new CreateComplaintUseCase.Command(reviewId));
+        createComplaintUseCase.invoke(reviewId);
     }
 
     @Override
     public void deleteComplain(Long reviewId) {
-        deleteComplaintUseCase.invoke(new DeleteComplaintUseCase.Command(reviewId));
+        deleteComplaintUseCase.invoke(reviewId);
     }
 
     @Override
     public void like(Long reviewId) {
-        createLikeUseCase.invoke(new CreateLikeUseCase.Command(reviewId));
+        createLikeUseCase.invoke(reviewId);
     }
 
     @Override
     public void unLike(Long reviewId) {
-        deleteLikeUseCase.invoke(new DeleteLikeUseCase.Command(reviewId));
+        deleteLikeUseCase.invoke(reviewId);
     }
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/search/controller/SearchController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/search/controller/SearchController.java
@@ -15,8 +15,7 @@ public class SearchController implements SearchApi {
 
     @Override
     public SuccessResponse<GetPerfumesResponse> findAllPerfumesByKeyword(String keyword) {
-        GetPerfumesByKeywordUseCase.Result result = getPerfumesByKeywordUseCase.invoke(
-            new GetPerfumesByKeywordUseCase.Command(keyword));
+        GetPerfumesByKeywordUseCase.Result result = getPerfumesByKeywordUseCase.invoke(keyword);
 
         return SuccessResponse.of(new GetPerfumesResponse(result.perfumeDTOs()));
     }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/api/UserApi.java
@@ -151,6 +151,6 @@ public interface UserApi {
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/my/withdraw")
     @ResponseStatus(HttpStatus.OK)
-    SuccessResponse<String> withdraw();
+    void withdraw();
 
 }

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -55,11 +55,9 @@ public class UserController implements UserApi {
         MultipartFile picture
     ) {
         UpdateProfileUseCase.Result result = updateProfileUseCase.invoke(
-            new UpdateProfileUseCase.Command(
-                nickname,
-                isChanged,
-                picture
-            )
+            nickname,
+            isChanged,
+            picture
         );
 
         return SuccessResponse.of(
@@ -114,10 +112,9 @@ public class UserController implements UserApi {
     public void createVisitHistory(Long perfumeId) {
         Instant searchAt = Instant.now();
 
-        createVisitHistoryUseCase.invoke(new CreateVisitHistoryUseCase.Command(
+        createVisitHistoryUseCase.invoke(
             perfumeId,
             searchAt
-            )
         );
     }
 
@@ -136,8 +133,7 @@ public class UserController implements UserApi {
     @Override
     public SuccessResponse<GetReviewByPerfumeIdAndUserResponse> findReviewByPerfumeIdAndUser(
         Long perfumeId) {
-        GetReviewByPerfumeIdAndUserUseCase.Result result = getReviewByPerfumeIdAndUserUseCase.invoke(
-            new GetReviewByPerfumeIdAndUserUseCase.Command(perfumeId));
+        GetReviewByPerfumeIdAndUserUseCase.Result result = getReviewByPerfumeIdAndUserUseCase.invoke(perfumeId);
 
         return SuccessResponse.of(new GetReviewByPerfumeIdAndUserResponse(result.reviewByUserDTO()));
     }
@@ -163,7 +159,7 @@ public class UserController implements UserApi {
 
     @Override
     public SuccessResponse<GetReviewsByUserAndSortTypeResponse> findAllReviewByUserAndSortType(String sortType) {
-        GetReviewsByUserAndSortTypeUseCase.Result result = getReviewsByUserAndSortTypeUseCase.invoke(new GetReviewsByUserAndSortTypeUseCase.Command(sortType));
+        GetReviewsByUserAndSortTypeUseCase.Result result = getReviewsByUserAndSortTypeUseCase.invoke(sortType);
 
         return SuccessResponse.of(
             new GetReviewsByUserAndSortTypeResponse(result.reviewWithPerfumeDTOs())

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -167,10 +167,8 @@ public class UserController implements UserApi {
     }
 
     @Override
-    public SuccessResponse<String> withdraw() {
+    public void withdraw() {
         deleteUserUseCase.invoke();
-
-        return SuccessResponse.of(null);
     }
 
 }


### PR DESCRIPTION
## Summary
  - UseCase에서 사용되는 입력모델인 Command를 제거했습니다.

## 고민했던 점
### 1. Command 사용의 본래 목적
  - Incoming port에서 Command를 사용하는 이유는 Web Layer로부터 받은 값의 유효성을 검증하고, 이를 Domain Layer에 전달하기 위함입니다.
  - 그러나, 본 프로젝트에서는 Command 객체가 유효성 검증의 역할을 수행하지 않고, 단순히 데이터를 감싸서 전달하는 용도로만 사용되었습니다.

### 2. Command 사용의 장단점
  - 장점 
    - Command를 사용하면 필요한 파라미터가 추가될 때 UseCase의 Command만 수정하면 되므로 확장성이 있습니다. 
    - 또한, UseCase에서 명시적인 입력 모델로 입력값을 관리할 수 있습니다.

  - 단점
    - 본 프로젝트에서는 Command가 유효성 검증을 하지 않기 때문에, 중간 객체로서의 역할이 명확하지 않아 불필요한 복잡성이 발생합니다. 
    - 단순한 입력값 전달을 위해 Command은 오히려 불필요한 코드 증가로 이어질 수 있습니다.

### 3. 유효성 검증의 책임 위치
  - 유효성 검증은 Web Layer에서 수행하고 있으며, UseCase로 전달되는 데이터는 이미 검증된 상태입니다.
  - 따라서 UseCase에서 Command를 사용하는 것은 비효율적이라고 판단했습니다.