### PR TITLE
[PERPICK-011] (statistic) GetPerfumeStatisticByPerfumeIdUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/statistic/port/in/GetPerfumeStatisticUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/port/in/GetPerfumeStatisticUseCase.java
@@ -5,7 +5,7 @@ import com.pikachu.purple.domain.evaluation.dto.EvaluationFieldDTO;
 import com.pikachu.purple.domain.evaluation.dto.EvaluationOptionStatisticDTO;
 import java.util.List;
 
-public interface GetPerfumeStatisticByPerfumeIdUseCase {
+public interface GetPerfumeStatisticUseCase {
 
     Result invoke(Long perfumeId);
 

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticByPerfumeIdService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class GetPerfumeStatisticByPerfumeIdApplicationService implements
+class GetPerfumeStatisticByPerfumeIdService implements
     GetPerfumeStatisticByPerfumeIdUseCase {
 
     private final EvaluationStatisticDomainService evaluationStatisticDomainService;

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/GetPerfumeStatisticService.java
@@ -1,7 +1,7 @@
 package com.pikachu.purple.application.statistic.service.application;
 
 import com.pikachu.purple.application.statistic.common.dto.StarRatingStatisticDTO;
-import com.pikachu.purple.application.statistic.port.in.GetPerfumeStatisticByPerfumeIdUseCase;
+import com.pikachu.purple.application.statistic.port.in.GetPerfumeStatisticUseCase;
 import com.pikachu.purple.application.statistic.service.domain.EvaluationStatisticDomainService;
 import com.pikachu.purple.application.statistic.service.domain.StarRatingStatisticDomainService;
 import com.pikachu.purple.domain.evaluation.dto.EvaluationFieldDTO;
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class GetPerfumeStatisticByPerfumeIdService implements
-    GetPerfumeStatisticByPerfumeIdUseCase {
+class GetPerfumeStatisticService implements
+    GetPerfumeStatisticUseCase {
 
     private final EvaluationStatisticDomainService evaluationStatisticDomainService;
     private final StarRatingStatisticDomainService starRatingStatisticDomainService;

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.bootstrap.perfume.controller;
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumeDetailByPerfumeIdUseCase;
 import com.pikachu.purple.application.perfume.port.in.fragranticaevaluation.GetFragranticaEvaluationByPerfumeIdUseCase;
 import com.pikachu.purple.application.review.port.in.review.GetReviewsByPerfumeIdAndSortTypeUseCase;
-import com.pikachu.purple.application.statistic.port.in.GetPerfumeStatisticByPerfumeIdUseCase;
+import com.pikachu.purple.application.statistic.port.in.GetPerfumeStatisticUseCase;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.perfume.api.PerfumeApi;
 import com.pikachu.purple.bootstrap.perfume.dto.response.GetPerfumeDetailResponse;
@@ -19,7 +19,7 @@ public class PerfumeController implements PerfumeApi {
 
     private final GetPerfumeDetailByPerfumeIdUseCase getPerfumeDetailByPerfumeIdUseCase;
     private final GetFragranticaEvaluationByPerfumeIdUseCase getFragranticaEvaluationByPerfumeIdUseCase;
-    private final GetPerfumeStatisticByPerfumeIdUseCase getPerfumeStatisticByPerfumeIdUseCase;
+    private final GetPerfumeStatisticUseCase getPerfumeStatisticUseCase;
     private final GetReviewsByPerfumeIdAndSortTypeUseCase getReviewsByPerfumeIdAndSortTypeUseCase;
 
     @Override
@@ -42,7 +42,7 @@ public class PerfumeController implements PerfumeApi {
     @Override
     public SuccessResponse<GetPerfumeStatisticResponse> findPerfumeStatisticResponse(
         Long perfumeId) {
-        GetPerfumeStatisticByPerfumeIdUseCase.Result result = getPerfumeStatisticByPerfumeIdUseCase.invoke(perfumeId);
+        GetPerfumeStatisticUseCase.Result result = getPerfumeStatisticUseCase.invoke(perfumeId);
 
         return SuccessResponse.of(
             new GetPerfumeStatisticResponse(


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
-  메소드명 invoke()로 통일
- Command 제거

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4