### PR TITLE
[PERPICK-024] (review > review) GetReviewsByPerfumeIdAndSortTypeUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/GetReviewsUseCase.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.application.review.port.in.review;
 import com.pikachu.purple.application.review.common.dto.ReviewDTO;
 import java.util.List;
 
-public interface GetReviewsByPerfumeIdAndSortTypeUseCase {
+public interface GetReviewsUseCase {
 
     Result invoke(
         Long perfumeId,

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetReviewsService.java
@@ -5,7 +5,7 @@ import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUse
 import com.pikachu.purple.application.review.common.dto.ReviewDTO;
 import com.pikachu.purple.application.review.common.dto.ReviewEvaluationFieldDTO;
 import com.pikachu.purple.application.review.common.dto.ReviewEvaluationOptionDTO;
-import com.pikachu.purple.application.review.port.in.review.GetReviewsByPerfumeIdAndSortTypeUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetReviewsUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.Mood;
 import com.pikachu.purple.domain.review.Review;
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-class GetReviewsByPerfumeIdAndSortTypeApplicationService implements
-    GetReviewsByPerfumeIdAndSortTypeUseCase {
+class GetReviewsService implements
+    GetReviewsUseCase {
 
     private final ReviewDomainService reviewDomainService;
 

--- a/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/perfume/controller/PerfumeController.java
@@ -2,7 +2,7 @@ package com.pikachu.purple.bootstrap.perfume.controller;
 
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumeDetailByPerfumeIdUseCase;
 import com.pikachu.purple.application.perfume.port.in.fragranticaevaluation.GetFragranticaEvaluationByPerfumeIdUseCase;
-import com.pikachu.purple.application.review.port.in.review.GetReviewsByPerfumeIdAndSortTypeUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetReviewsUseCase;
 import com.pikachu.purple.application.statistic.port.in.GetPerfumeStatisticUseCase;
 import com.pikachu.purple.bootstrap.common.dto.SuccessResponse;
 import com.pikachu.purple.bootstrap.perfume.api.PerfumeApi;
@@ -20,7 +20,7 @@ public class PerfumeController implements PerfumeApi {
     private final GetPerfumeDetailByPerfumeIdUseCase getPerfumeDetailByPerfumeIdUseCase;
     private final GetFragranticaEvaluationByPerfumeIdUseCase getFragranticaEvaluationByPerfumeIdUseCase;
     private final GetPerfumeStatisticUseCase getPerfumeStatisticUseCase;
-    private final GetReviewsByPerfumeIdAndSortTypeUseCase getReviewsByPerfumeIdAndSortTypeUseCase;
+    private final GetReviewsUseCase getReviewsUseCase;
 
     @Override
     public SuccessResponse<GetPerfumeDetailResponse> findAccordsAndNotesByPerfumeId(Long perfumeId) {
@@ -57,7 +57,7 @@ public class PerfumeController implements PerfumeApi {
         Long perfumeId,
         String sortType
     ) {
-        GetReviewsByPerfumeIdAndSortTypeUseCase.Result result = getReviewsByPerfumeIdAndSortTypeUseCase.invoke(
+        GetReviewsUseCase.Result result = getReviewsUseCase.invoke(
             perfumeId,
             sortType
         );


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
-  메소드명 invoke()로 통일
- Command 제거

### 수정 유스케이스 목록
- GetReviewsByPerfumeIdAndSortTypeUseCase → GetReviewsUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4