### PR TITLE
[PERPICK-025] (review > review) GetReviewsDetailWithEvaluationUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/review/port/in/review/GetDetailedReviewsUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/review/port/in/review/GetDetailedReviewsUseCase.java
@@ -3,7 +3,7 @@ package com.pikachu.purple.application.review.port.in.review;
 import com.pikachu.purple.domain.review.Review;
 import java.util.List;
 
-public interface GetReviewsDetailWithEvaluationUseCase {
+public interface GetDetailedReviewsUseCase {
 
     Result invoke();
 

--- a/src/main/java/com/pikachu/purple/application/review/service/application/review/GetDetailedReviewsService.java
+++ b/src/main/java/com/pikachu/purple/application/review/service/application/review/GetDetailedReviewsService.java
@@ -1,6 +1,6 @@
 package com.pikachu.purple.application.review.service.application.review;
 
-import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetDetailedReviewsUseCase;
 import com.pikachu.purple.application.review.service.domain.ReviewDomainService;
 import com.pikachu.purple.domain.review.Review;
 import com.pikachu.purple.domain.review.enums.ReviewType;
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-class GetReviewsDetailWithEvaluationApplicationService implements
-    GetReviewsDetailWithEvaluationUseCase {
+class GetDetailedReviewsService implements
+    GetDetailedReviewsUseCase {
 
     private final ReviewDomainService reviewDomainService;
 

--- a/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/RecountEvaluationStatisticsService.java
+++ b/src/main/java/com/pikachu/purple/application/statistic/service/application/evaluationstatistic/RecountEvaluationStatisticsService.java
@@ -1,7 +1,7 @@
 package com.pikachu.purple.application.statistic.service.application.evaluationstatistic;
 
 import com.pikachu.purple.application.perfume.port.in.perfume.GetPerfumeIdsUseCase;
-import com.pikachu.purple.application.review.port.in.review.GetReviewsDetailWithEvaluationUseCase;
+import com.pikachu.purple.application.review.port.in.review.GetDetailedReviewsUseCase;
 import com.pikachu.purple.application.statistic.port.in.evaluationstatistic.RecountEvaluationStatisticsUseCase;
 import com.pikachu.purple.application.statistic.service.domain.EvaluationStatisticDomainService;
 import com.pikachu.purple.domain.review.Review;
@@ -16,7 +16,7 @@ class RecountEvaluationStatisticsService implements
     RecountEvaluationStatisticsUseCase {
 
     private final EvaluationStatisticDomainService evaluationStatisticDomainService;
-    private final GetReviewsDetailWithEvaluationUseCase getReviewsDetailWithEvaluationUseCase;
+    private final GetDetailedReviewsUseCase getDetailedReviewsUseCase;
     private final GetPerfumeIdsUseCase getPerfumeIdsUseCase;
 
     @Override
@@ -26,7 +26,7 @@ class RecountEvaluationStatisticsService implements
         List<Long> perfumeIds = getPerfumeIdsUseCase.invoke().perfumeIds();
         perfumeIds.forEach(evaluationStatistic::setDefault);
 
-        List<Review> reviews = getReviewsDetailWithEvaluationUseCase.invoke()
+        List<Review> reviews = getDetailedReviewsUseCase.invoke()
             .reviews();
 
         reviews.forEach(


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
-  메소드명 invoke()로 통일
- Command 제거

### 수정 유스케이스 목록
- GetReviewsDetailWithEvaluationUseCase → GetDetailedReviewsUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4