### PR TITLE
[PERPICK-034] (history > history) CreateSearchHistoryUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/CreateSearchHistoryUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/CreateSearchHistoryUseCase.java
@@ -4,7 +4,8 @@ import java.time.Instant;
 
 public interface CreateSearchHistoryUseCase {
 
-    void invoke(
+    void create(
+        Long userId,
         String keyword,
         Instant searchAt
     );

--- a/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/CreateSearchHistoryService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/CreateSearchHistoryService.java
@@ -1,7 +1,5 @@
 package com.pikachu.purple.application.history.service.application.searchhistory;
 
-import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
-
 import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.history.service.domain.SearchHistoryDomainService;
 import java.time.Instant;
@@ -10,17 +8,16 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class CreateSearchHistoryApplicationService implements CreateSearchHistoryUseCase {
+class CreateSearchHistoryService implements CreateSearchHistoryUseCase {
 
     private final SearchHistoryDomainService searchHistoryDomainService;
 
     @Override
-    public void invoke(
+    public void create(
+        Long userId,
         String keyword,
         Instant searchAt
     ) {
-        Long userId = getCurrentUserAuthentication().userId();
-
         searchHistoryDomainService.validateNotExist(
             userId,
             keyword

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.bootstrap.user.controller;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.DeleteSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.GetSearchHistoriesUseCase;
@@ -89,8 +91,11 @@ public class UserController implements UserApi {
 
     @Override
     public void createSearchHistory(String keyword) {
+        Long userId = getCurrentUserAuthentication().userId();
         Instant searchAt = Instant.now();
-        createSearchHistoryUseCase.invoke(
+
+        createSearchHistoryUseCase.create(
+            userId,
             keyword,
             searchAt
         );


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
- Command 제거

## 수정된 UseCase 목록
- CreateSearchHistoryUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4