### PR TITLE
[PERPICK-035] (history > history) DeleteSearchHistoriesUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/DeleteSearchHistoriesUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/DeleteSearchHistoriesUseCase.java
@@ -2,6 +2,6 @@ package com.pikachu.purple.application.history.port.in.searchhistory;
 
 public interface DeleteSearchHistoriesUseCase {
 
-    void invoke();
+    void deleteAll(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/DeleteSearchHistoriesService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/DeleteSearchHistoriesService.java
@@ -1,7 +1,5 @@
 package com.pikachu.purple.application.history.service.application.searchhistory;
 
-import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
-
 import com.pikachu.purple.application.history.port.in.searchhistory.DeleteSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.service.domain.SearchHistoryDomainService;
 import lombok.RequiredArgsConstructor;
@@ -9,14 +7,13 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class DeleteSearchHistoriesApplicationService implements
+class DeleteSearchHistoriesService implements
     DeleteSearchHistoriesUseCase {
 
     private final SearchHistoryDomainService searchHistoryDomainService;
 
     @Override
-    public void invoke() {
-        Long userId = getCurrentUserAuthentication().userId();
+    public void deleteAll(Long userId) {
         searchHistoryDomainService.deleteAllSearchHistoryByUserId(userId);
     }
 

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.bootstrap.user.controller;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.DeleteSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.GetSearchHistoriesUseCase;
@@ -105,7 +107,9 @@ public class UserController implements UserApi {
 
     @Override
     public void deleteAllSearchHistory() {
-        deleteSearchHistoriesUseCase.invoke();
+        Long userId = getCurrentUserAuthentication().userId();
+
+        deleteSearchHistoriesUseCase.deleteAll(userId);
     }
 
     @Override


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
- Command 제거

## 수정된 UseCase 목록
- DeleteSearchHistoriesUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4