### PR TITLE
[PERPICK-036] (history > history) GetSearchHistoriesUseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/GetSearchHistoriesUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/searchhistory/GetSearchHistoriesUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface GetSearchHistoriesUseCase {
 
-    Result invoke();
+    Result findAll(Long userId);
 
     record Result(List<SearchHistoryDTO> searchHistories){}
 

--- a/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/GetSearchHistoriesService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/searchhistory/GetSearchHistoriesService.java
@@ -1,7 +1,5 @@
 package com.pikachu.purple.application.history.service.application.searchhistory;
 
-import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
-
 import com.pikachu.purple.application.history.common.dto.SearchHistoryDTO;
 import com.pikachu.purple.application.history.port.in.searchhistory.GetSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.service.domain.SearchHistoryDomainService;
@@ -13,14 +11,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class GetSearchHistoriesApplicationService implements GetSearchHistoriesUseCase {
+class GetSearchHistoriesService implements GetSearchHistoriesUseCase {
 
     private final SearchHistoryDomainService searchHistoryDomainService;
 
     @Override
-    public Result invoke() {
-        Long userId = getCurrentUserAuthentication().userId();
-
+    public Result findAll(Long userId) {
         List<SearchHistory> searchHistories = searchHistoryDomainService.findAllByUserId(userId);
 
         List<SearchHistoryDTO> searchHistoryDTOs = IntStream.range(0, searchHistories.size())

--- a/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
+++ b/src/main/java/com/pikachu/purple/bootstrap/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.pikachu.purple.bootstrap.user.controller;
 
+import static com.pikachu.purple.support.security.SecurityProvider.getCurrentUserAuthentication;
+
 import com.pikachu.purple.application.history.port.in.searchhistory.CreateSearchHistoryUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.DeleteSearchHistoriesUseCase;
 import com.pikachu.purple.application.history.port.in.searchhistory.GetSearchHistoriesUseCase;
@@ -98,7 +100,8 @@ public class UserController implements UserApi {
 
     @Override
     public SuccessResponse<GetSearchHistoriesResponse> findAllSearchHistory() {
-        GetSearchHistoriesUseCase.Result result = getSearchHistoriesUseCase.invoke();
+        Long userId = getCurrentUserAuthentication().userId();
+        GetSearchHistoriesUseCase.Result result = getSearchHistoriesUseCase.findAll(userId);
 
         return SuccessResponse.of(new GetSearchHistoriesResponse(result.searchHistories()));
     }


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
- Command 제거

## 수정된 UseCase 목록
- GetSearchHistoriesUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4