### PR TITLE
[PERPICK-046] VisitHistory 관련 UseCase 리팩토링

### DIFF
--- a/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/CreateVisitHistoryUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/CreateVisitHistoryUseCase.java
@@ -4,7 +4,8 @@ import java.time.Instant;
 
 public interface CreateVisitHistoryUseCase {
 
-    void invoke(
+    void create(
+        Long userId,
         Long perfumeId,
         Instant searchAt
     );

--- a/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/DeleteVisitHistoriesUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/DeleteVisitHistoriesUseCase.java
@@ -2,6 +2,6 @@ package com.pikachu.purple.application.history.port.in.visithistory;
 
 public interface DeleteVisitHistoriesUseCase {
 
-    void invoke();
+    void deleteAll(Long userId);
 
 }

--- a/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/GetVisitHistoriesUseCase.java
+++ b/src/main/java/com/pikachu/purple/application/history/port/in/visithistory/GetVisitHistoriesUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface GetVisitHistoriesUseCase {
 
-    Result invoke();
+    Result findAll(Long userId);
 
     record Result(List<VisitHistoryDTO> visitHistoryDTOs) {}
 

--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/CreateVisitHistoryApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/CreateVisitHistoryApplicationService.java
@@ -17,12 +17,11 @@ class CreateVisitHistoryApplicationService implements CreateVisitHistoryUseCase 
 
     @Transactional
     @Override
-    public void invoke(
+    public void create(
+        Long userId,
         Long perfumeId,
         Instant searchAt
     ) {
-        Long userId = getCurrentUserAuthentication().userId();
-
         visitHistoryDomainService.validateNotExist(
             userId,
             perfumeId

--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/DeleteVisitHistoriesApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/DeleteVisitHistoriesApplicationService.java
@@ -16,9 +16,7 @@ class DeleteVisitHistoriesApplicationService implements DeleteVisitHistoriesUseC
 
     @Transactional
     @Override
-    public void invoke() {
-        Long userId = getCurrentUserAuthentication().userId();
-
+    public void deleteAll(Long userId) {
         visitHistoryDomainService.deleteAllVisitHistoryByUserId(userId);
     }
 

--- a/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
+++ b/src/main/java/com/pikachu/purple/application/history/service/application/visithistory/GetVisitHistoriesApplicationService.java
@@ -28,9 +28,7 @@ class GetVisitHistoriesApplicationService implements GetVisitHistoriesUseCase {
 
     @Transactional
     @Override
-    public Result invoke() {
-        Long userId = getCurrentUserAuthentication().userId();
-
+    public Result findAll(Long userId) {
         List<VisitHistory> visitHistories = visitHistoryDomainService.findAllByUserId(userId);
 
         List<Long> perfumeIds = visitHistories.stream()


### PR DESCRIPTION
## 리팩토링 사항
- In Port UseCase 클래스 명명 규칙 적용 + 유스케이스 분리/통합(오버로딩)
- Service 클래스 명명 규칙 적용
- 유즈케이스 행위는 같지만 파라미터가 다를 경우 → 오버로딩
- Command 제거

## 수정된 UseCase 목록
- CreateVisitHistoryUseCase
- DeleteVisitHistoriesUseCase
- GetVisitHistoriesUseCase

### 자세한 리팩토링 기준 참고
> https://ember-bluebell-522.notion.site/c23039c416554ae19a4e4aa11ce77d0c?pvs=4